### PR TITLE
Fix proof metadata collection and closes-issue PR linking

### DIFF
--- a/.conductor/WORKFLOW.md
+++ b/.conductor/WORKFLOW.md
@@ -76,13 +76,18 @@ Create this file at `.conductor/workpad.md` at the start of every run:
 
 ## Step 4 — PR and handoff
 
-1. Push branch and open a PR targeting `main`:
-   `gh pr create --title "..." --body "..." --repo <owner/repo>`
-2. Attach the PR to the issue.
-3. Poll PR checks — loop until green or until a failure requires a code fix.
-4. Run a PR feedback sweep (inline comments + review summaries); address or
+1. Push branch and open a PR targeting `main`. Include `Closes #<issue-number>`
+   in the PR body (the issue number is in the task header above):
+   `gh pr create --title "..." --body "Closes #N\n\n..." --repo <owner/repo>`
+2. Capture the PR URL and write it to `.conductor/metadata.json`:
+   ```json
+   {"pr_url": "https://github.com/org/repo/pull/N"}
+   ```
+3. Attach the PR to the issue.
+4. Poll PR checks — loop until green or until a failure requires a code fix.
+5. Run a PR feedback sweep (inline comments + review summaries); address or
    explicitly respond to every actionable comment.
-5. Move issue to **Human Review**.
+6. Move issue to **Human Review**.
 
 ## Step 5 — Rework (if returned)
 

--- a/internal/proof/collector.go
+++ b/internal/proof/collector.go
@@ -65,13 +65,39 @@ func (c *Collector) Collect(ctx context.Context, run *domain.Run, task *domain.T
 		bundle.DurationSeconds = time.Since(started).Seconds()
 	}
 
-	// 4. Write summary.json.
+	// 4. Merge agent-written metadata (pr_url, walkthrough, etc.).
+	readAgentMetadata(run.WorktreePath, bundle)
+
+	// 5. Write summary.json.
 	summaryPath := filepath.Join(run.WorktreePath, "proof", "summary.json")
 	if err := writeSummary(summaryPath, bundle); err != nil {
 		return nil, fmt.Errorf("write summary: %w", err)
 	}
 
 	return bundle, nil
+}
+
+// readAgentMetadata merges fields from .conductor/metadata.json (written by the
+// agent) into bundle. Unknown fields are ignored; missing file is not an error.
+func readAgentMetadata(worktreePath string, bundle *domain.ProofBundle) {
+	path := filepath.Join(worktreePath, ".conductor", "metadata.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var meta struct {
+		PRUrl       string `json:"pr_url"`
+		Walkthrough string `json:"walkthrough"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return
+	}
+	if meta.PRUrl != "" {
+		bundle.PRUrl = meta.PRUrl
+	}
+	if meta.Walkthrough != "" {
+		bundle.Walkthrough = meta.Walkthrough
+	}
 }
 
 // runCI executes the test suite in the worktree directory.
@@ -102,8 +128,24 @@ func (c *Collector) runCI(ctx context.Context, dir string) (domain.CIResult, err
 
 // diffStats returns line-count statistics comparing the worktree HEAD to baseBranch.
 func (c *Collector) diffStats(dir, baseBranch string) (domain.DiffStat, error) {
-	// git diff --shortstat <base>...HEAD
-	cmd := exec.Command("git", "diff", "--shortstat", baseBranch+"...HEAD")
+	// Find the common ancestor explicitly — more reliable in detached worktrees
+	// than the three-dot syntax.
+	baseRef := "origin/" + baseBranch
+	mbCmd := exec.Command("git", "merge-base", "HEAD", baseRef)
+	mbCmd.Dir = dir
+	mergeBase, err := mbCmd.Output()
+	if err != nil {
+		// Fall back to the local branch name.
+		mbCmd2 := exec.Command("git", "merge-base", "HEAD", baseBranch)
+		mbCmd2.Dir = dir
+		mergeBase, err = mbCmd2.Output()
+		if err != nil {
+			return domain.DiffStat{}, fmt.Errorf("git merge-base: %w", err)
+		}
+	}
+	base := strings.TrimSpace(string(mergeBase))
+
+	cmd := exec.Command("git", "diff", "--shortstat", base, "HEAD")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -260,6 +260,11 @@ func buildTaskPrompt(task *domain.Task, workflow string) []byte {
 	if task.SourceURL != "" {
 		fmt.Fprintf(&b, "**Source:** %s\n", task.SourceURL)
 	}
+	if task.Source == "github" {
+		if n := githubIssueNumber(task.SourceURL); n != "" {
+			fmt.Fprintf(&b, "**Issue number:** %s (use `Closes #%s` in the PR description)\n", n, n)
+		}
+	}
 	if len(task.Labels) > 0 {
 		fmt.Fprintf(&b, "**Labels:** %s\n", strings.Join(task.Labels, ", "))
 	}
@@ -267,4 +272,14 @@ func buildTaskPrompt(task *domain.Task, workflow string) []byte {
 	b.WriteString(task.Description)
 	b.WriteString("\n")
 	return []byte(b.String())
+}
+
+// githubIssueNumber extracts the issue number from a GitHub issue URL.
+// e.g. "https://github.com/org/repo/issues/42" -> "42"
+func githubIssueNumber(sourceURL string) string {
+	parts := strings.Split(sourceURL, "/issues/")
+	if len(parts) == 2 && parts[1] != "" {
+		return strings.TrimRight(parts[1], "/")
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary

- **Diff stats fixed**: proof collector now uses `git merge-base HEAD origin/main` to find the true common ancestor before diffing — the previous three-dot syntax was unreliable in detached worktrees and consistently returned 0
- **PR URL captured**: collector reads `.conductor/metadata.json` from the worktree (written by the agent after `gh pr create`) to populate `pr_url` and `walkthrough` in the proof bundle
- **Closes #N**: task prompt now includes the GitHub issue number with an explicit `Closes #N` instruction; WORKFLOW.md updated to match
- **WORKFLOW.md**: Step 4 instructs agent to write `metadata.json` with the PR URL immediately after opening the PR

## Test plan

- [ ] `go test ./...` passes
- [ ] Create a GitHub issue labelled `conductor` — verify the task prompt contains `Issue number: #N (use Closes #N in the PR description)`
- [ ] After the run, confirm `.conductor/metadata.json` exists in the worktree with `pr_url` populated
- [ ] Confirm `proof/summary.json` shows non-zero diff stats and the correct `pr_url`
- [ ] Confirm the opened PR description contains `Closes #N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)