### PR TITLE
ci: GitHub Actions for test, build, and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+      - name: Build (non-Windows)
+        if: runner.os != 'Windows'
+        run: go build -o conductor-${{ runner.os }} ./cmd/conductor
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: go build -o conductor-${{ runner.os }}.exe ./cmd/conductor
+      - name: Upload artifact (non-Windows)
+        if: runner.os != 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: conductor-${{ runner.os }}
+          path: conductor-${{ runner.os }}
+      - name: Upload artifact (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: conductor-${{ runner.os }}
+          path: conductor-${{ runner.os }}.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+      - run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            artifact: conductor-linux-amd64
+          - goos: linux
+            goarch: arm64
+            artifact: conductor-linux-arm64
+          - goos: darwin
+            goarch: amd64
+            artifact: conductor-darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            artifact: conductor-darwin-arm64
+          - goos: windows
+            goarch: amd64
+            artifact: conductor-windows-amd64.exe
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          ARTIFACT: ${{ matrix.artifact }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          go build -ldflags="-s -w -X main.version=${REF_NAME}" \
+            -o "${ARTIFACT}" ./cmd/conductor
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
+  create-release:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: dist/**/*

--- a/cmd/conductor/main.go
+++ b/cmd/conductor/main.go
@@ -22,6 +22,8 @@ import (
 	"github.com/haha-systems/conductor/internal/worksource"
 )
 
+var version = "dev"
+
 func main() {
 	if err := rootCmd().Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- Adds `ci.yml`: runs `go test ./...` on every push and on PRs to `main`
- Adds `build.yml`: matrix build across ubuntu/macos/windows on push/PR to `main`, uploads artifacts
- Adds `release.yml`: cross-compiles for 5 platforms (linux/darwin amd64+arm64, windows amd64) on `v*.*.*` tag push, creates a GitHub Release with all binaries
- Adds `var version = "dev"` to `cmd/conductor/main.go` so the release `-ldflags` `-X main.version` injection doesn't cause a linker error

Closes #8