### PR TITLE
fix: Windows build failure — split Unix-only syscall code into platform files

### DIFF
--- a/internal/provider/shell.go
+++ b/internal/provider/shell.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"syscall"
 	"time"
 )
 
@@ -44,7 +43,7 @@ func (a *shellAdapter) adapterRunWithStdin(ctx context.Context, rc RunContext, s
 	cmd.Stdin = stdin
 	cmd.Stdout = rc.LogWriter
 	cmd.Stderr = rc.LogWriter
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcAttr(cmd)
 
 	if err := cmd.Start(); err != nil {
 		if stdin != nil {
@@ -72,20 +71,7 @@ func (h *processHandle) Wait() error {
 // Cancel sends SIGTERM to the process group, then schedules SIGKILL after a
 // grace period. It does NOT call Wait — the caller owns exactly one Wait call.
 func (h *processHandle) Cancel() error {
-	if h.cmd.Process == nil {
-		return nil
-	}
-	pgid := -h.cmd.Process.Pid
-	if err := syscall.Kill(pgid, syscall.SIGTERM); err != nil {
-		if err == syscall.ESRCH {
-			return nil // already exited
-		}
-		return fmt.Errorf("cancel SIGTERM: %w", err)
-	}
-	time.AfterFunc(killGrace, func() {
-		syscall.Kill(pgid, syscall.SIGKILL) //nolint:errcheck
-	})
-	return nil
+	return cancelProcess(h.cmd)
 }
 
 // buildEnv merges RunContext.Env on top of the current process environment.

--- a/internal/provider/shell_unix.go
+++ b/internal/provider/shell_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package provider
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func setProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func cancelProcess(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	pgid := -cmd.Process.Pid
+	if err := syscall.Kill(pgid, syscall.SIGTERM); err != nil {
+		if err == syscall.ESRCH {
+			return nil
+		}
+		return fmt.Errorf("cancel SIGTERM: %w", err)
+	}
+	time.AfterFunc(killGrace, func() {
+		syscall.Kill(pgid, syscall.SIGKILL) //nolint:errcheck
+	})
+	return nil
+}

--- a/internal/provider/shell_windows.go
+++ b/internal/provider/shell_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package provider
+
+import (
+	"os"
+	"os/exec"
+)
+
+func setProcAttr(cmd *exec.Cmd) {
+	// No process group management on Windows
+}
+
+func cancelProcess(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Signal(os.Interrupt)
+}


### PR DESCRIPTION
## Summary

- Extracts `setProcAttr` and `cancelProcess` into `shell_unix.go` (`!windows` build tag) with the POSIX process-group logic
- Adds `shell_windows.go` (`windows` build tag) with stub `setProcAttr` and `cmd.Process.Signal(os.Interrupt)` fallback
- `shell.go` now calls the helpers and imports no platform-specific packages

## Verification

- `go build ./...` ✅
- `GOOS=windows GOARCH=amd64 go build ./...` ✅
- `go test ./...` ✅ (all 6 packages pass)

Closes #10