### PR TITLE
feat: agent-driven PR rebase with 3-strike guardrail

### DIFF
--- a/.conductor/REBASE_WORKFLOW.md
+++ b/.conductor/REBASE_WORKFLOW.md
@@ -1,0 +1,6 @@
+You are rebasing a pull request branch. Your job is to bring the branch up to date
+with its base branch by replaying its commits on top of the latest base.
+
+When resolving conflicts, prefer preserving the intent of the incoming PR changes
+while incorporating any structural changes from the base branch. If you cannot
+determine the correct resolution, exit non-zero and explain what you saw.

--- a/cmd/conductor/main.go
+++ b/cmd/conductor/main.go
@@ -288,6 +288,7 @@ func executeRace(
 				Task:     task,
 				Provider: p,
 				Persona:  route.Persona,
+				Source:   source,
 			})
 			ch <- outcome{result: result, p: p}
 		}()
@@ -335,11 +336,17 @@ func executeRun(
 		Task:     task,
 		Provider: p,
 		Persona:  persona,
+		Source:   source,
 	})
 	if result.Err != nil {
 		log.Error("run failed", "run_id", run.ID, "error", result.Err)
-		source.PostResult(ctx, task, fmt.Sprintf("Run failed: %v", result.Err)) //nolint:errcheck
+		if task.Type != domain.TaskTypeRebase {
+			source.PostResult(ctx, task, fmt.Sprintf("Run failed: %v", result.Err)) //nolint:errcheck
+		}
 		return
+	}
+	if task.Type == domain.TaskTypeRebase {
+		return // outcome already recorded by supervisor via RecordRebaseOutcome
 	}
 	finishRun(ctx, run, task, collector, source, hooks, log)
 }

--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -20,6 +20,16 @@ const (
 	TaskStatusLanded    TaskStatus = "landed"
 )
 
+// TaskType distinguishes the kind of work a task represents.
+type TaskType string
+
+const (
+	// TaskTypeIssue is the default — a task sourced from an issue/ticket.
+	TaskTypeIssue TaskType = "issue"
+	// TaskTypeRebase is a task to rebase a PR branch onto its base branch.
+	TaskTypeRebase TaskType = "rebase"
+)
+
 // TaskConfig holds the optional conductor: front-matter parsed from a task description.
 type TaskConfig struct {
 	Agent          string            `yaml:"agent"`
@@ -41,6 +51,14 @@ type Task struct {
 	SourceURL   string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	// Type identifies the kind of task. Defaults to TaskTypeIssue for backward compat.
+	Type TaskType
+	// Branch is the PR head branch for rebase tasks (e.g. "ci/github-actions-workflows").
+	Branch string
+	// BaseBranch is the branch to rebase onto for rebase tasks (e.g. "main").
+	BaseBranch string
+	// Attempts is the number of rebase attempts already recorded by the WorkSource.
+	Attempts int
 }
 
 // frontMatterMarker is the YAML front-matter delimiter.

--- a/internal/domain/task_test.go
+++ b/internal/domain/task_test.go
@@ -76,6 +76,45 @@ Do the thing`
 	}
 }
 
+func TestTaskType_DefaultIsIssue(t *testing.T) {
+	task := &Task{}
+	// Zero value of TaskType is "", not "issue" — callers should treat "" as issue.
+	// Verify the constant values are as expected.
+	if TaskTypeIssue != "issue" {
+		t.Errorf("expected TaskTypeIssue=\"issue\", got %q", TaskTypeIssue)
+	}
+	if TaskTypeRebase != "rebase" {
+		t.Errorf("expected TaskTypeRebase=\"rebase\", got %q", TaskTypeRebase)
+	}
+	// A task constructed without setting Type has the zero value (empty string),
+	// which should be treated as issue by callers.
+	if task.Type == TaskTypeRebase {
+		t.Error("zero-value task should not be treated as rebase")
+	}
+}
+
+func TestTask_RebaseFields(t *testing.T) {
+	task := &Task{
+		ID:         "99",
+		Type:       TaskTypeRebase,
+		Branch:     "ci/github-actions-workflows",
+		BaseBranch: "main",
+		Attempts:   1,
+	}
+	if task.Type != TaskTypeRebase {
+		t.Errorf("expected type=rebase, got %q", task.Type)
+	}
+	if task.Branch != "ci/github-actions-workflows" {
+		t.Errorf("unexpected branch: %q", task.Branch)
+	}
+	if task.BaseBranch != "main" {
+		t.Errorf("unexpected base branch: %q", task.BaseBranch)
+	}
+	if task.Attempts != 1 {
+		t.Errorf("expected attempts=1, got %d", task.Attempts)
+	}
+}
+
 func TestParseFrontMatter_MissingClosingMarker(t *testing.T) {
 	desc := `---
 conductor:

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -16,6 +16,12 @@ import (
 	"github.com/haha-systems/conductor/internal/provider"
 )
 
+// RebaseRecorder is satisfied by any WorkSource that supports rebase outcome
+// recording. It is used by the supervisor without importing the worksource package.
+type RebaseRecorder interface {
+	RecordRebaseOutcome(ctx context.Context, task *domain.Task, succeeded bool, reason string) error
+}
+
 // RunRequest is submitted to the supervisor to start a run.
 type RunRequest struct {
 	Run      *domain.Run
@@ -25,6 +31,8 @@ type RunRequest struct {
 	GlobalEnv map[string]string
 	// Persona is the resolved persona for this run, or nil if none.
 	Persona *config.PersonaConfig
+	// Source is used by rebase tasks to record outcomes. Nil is safe for issue tasks.
+	Source RebaseRecorder
 }
 
 // Result is returned by the supervisor after a run terminates.
@@ -56,6 +64,10 @@ func New(cfg Config) *Supervisor {
 // Execute runs the task synchronously and returns when the run reaches a terminal state.
 // The caller is responsible for collecting proof afterwards.
 func (s *Supervisor) Execute(ctx context.Context, req RunRequest) *Result {
+	if req.Task.Type == domain.TaskTypeRebase {
+		return s.executeRebase(ctx, req)
+	}
+
 	run := req.Run
 	now := time.Now()
 	run.StartedAt = now
@@ -384,4 +396,165 @@ func githubIssueNumber(sourceURL string) string {
 		return strings.TrimRight(parts[1], "/")
 	}
 	return ""
+}
+
+// executeRebase handles a TaskTypeRebase run: it sets up a worktree with the PR
+// branch, builds a rebase prompt, runs the agent, and records the outcome.
+func (s *Supervisor) executeRebase(ctx context.Context, req RunRequest) *Result {
+	run := req.Run
+	now := time.Now()
+	run.StartedAt = now
+	run.Status = domain.RunStatusRunning
+
+	worktreePath := filepath.Join(s.cfg.RepoRoot, s.cfg.WorktreeBaseDir, run.ID)
+	run.WorktreePath = worktreePath
+
+	// Fetch so origin/<branch> is current.
+	fetchCmd := exec.Command("git", "fetch", "origin")
+	fetchCmd.Dir = s.cfg.RepoRoot
+	if out, err := fetchCmd.CombinedOutput(); err != nil {
+		return s.fail(run, fmt.Errorf("git fetch: %w: %s", err, out))
+	}
+
+	// Create worktree with the PR branch checked out.
+	if err := s.createRebaseBranchWorktree(worktreePath, req.Task.Branch); err != nil {
+		return s.fail(run, fmt.Errorf("create rebase worktree: %w", err))
+	}
+
+	// Build rebase prompt.
+	workflow := s.loadRebaseWorkflow()
+	prompt := buildRebasePrompt(req.Task, workflow)
+	taskFile := filepath.Join(worktreePath, ".conductor-task.md")
+	if err := os.WriteFile(taskFile, prompt, 0600); err != nil {
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("write task file: %w", err))
+	}
+
+	// Open run log.
+	if err := os.MkdirAll(filepath.Join(worktreePath, "proof"), 0755); err != nil {
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("create proof dir: %w", err))
+	}
+	logPath := filepath.Join(worktreePath, "run.jsonl")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("create run log: %w", err))
+	}
+	defer logFile.Close()
+
+	logWriter := &providerLogWriter{w: logFile}
+
+	// Apply timeout.
+	timeout := time.Duration(s.cfg.TimeoutMinutes) * time.Minute
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	rc := provider.RunContext{
+		RepoPath:       worktreePath,
+		TaskFile:       taskFile,
+		Env:            env,
+		LogWriter:      logWriter,
+		TimeoutSeconds: int(timeout.Seconds()),
+	}
+
+	logEvent(logFile, "run_started", map[string]any{
+		"run_id":   run.ID,
+		"provider": req.Provider.Name(),
+		"task_id":  run.TaskID,
+		"type":     "rebase",
+		"branch":   req.Task.Branch,
+	})
+
+	handle, err := req.Provider.Run(runCtx, rc)
+	if err != nil {
+		s.cleanup(run)
+		s.recordRebaseOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("launch provider: %w", err))
+	}
+
+	waitErr := handle.Wait()
+	finished := time.Now()
+	run.FinishedAt = &finished
+
+	if runCtx.Err() == context.DeadlineExceeded {
+		run.Status = domain.RunStatusTimeout
+		reason := fmt.Sprintf("run timed out after %d minutes", s.cfg.TimeoutMinutes)
+		logEvent(logFile, "run_timeout", map[string]any{"run_id": run.ID})
+		s.recordRebaseOutcome(ctx, req, false, reason)
+		if !s.cfg.PreserveOnFailure {
+			s.cleanup(run)
+		}
+		return &Result{Run: run, Err: fmt.Errorf("%s", reason)}
+	}
+
+	if waitErr != nil {
+		run.Status = domain.RunStatusFailed
+		run.ErrorMsg = waitErr.Error()
+		logEvent(logFile, "run_failed", map[string]any{"run_id": run.ID, "error": waitErr.Error()})
+		s.recordRebaseOutcome(ctx, req, false, waitErr.Error())
+		if !s.cfg.PreserveOnFailure {
+			s.cleanup(run)
+		}
+		return &Result{Run: run, Err: waitErr}
+	}
+
+	run.Status = domain.RunStatusSucceeded
+	logEvent(logFile, "run_succeeded", map[string]any{"run_id": run.ID})
+	s.recordRebaseOutcome(ctx, req, true, "")
+	if !s.cfg.PreserveOnFailure {
+		s.cleanup(run)
+	}
+	return &Result{Run: run}
+}
+
+func (s *Supervisor) recordRebaseOutcome(ctx context.Context, req RunRequest, succeeded bool, reason string) {
+	if req.Source == nil {
+		return
+	}
+	req.Source.RecordRebaseOutcome(ctx, req.Task, succeeded, reason) //nolint:errcheck
+}
+
+func (s *Supervisor) createRebaseBranchWorktree(path, branch string) error {
+	cmd := exec.Command("git", "worktree", "add", "-B", branch, path, "origin/"+branch)
+	cmd.Dir = s.cfg.RepoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, out)
+	}
+	return nil
+}
+
+// loadRebaseWorkflow reads .conductor/REBASE_WORKFLOW.md from the repo root.
+// Returns empty string if the file is absent.
+func (s *Supervisor) loadRebaseWorkflow() string {
+	path := filepath.Join(s.cfg.RepoRoot, ".conductor", "REBASE_WORKFLOW.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// buildRebasePrompt formats a rebase task into a prompt for the agent.
+func buildRebasePrompt(task *domain.Task, workflow string) []byte {
+	var b strings.Builder
+	if workflow != "" {
+		b.WriteString(workflow)
+		b.WriteString("\n\n---\n\n")
+	}
+	fmt.Fprintf(&b, "# Task: Rebase `%s` onto `%s`\n\n", task.Branch, task.BaseBranch)
+	fmt.Fprintf(&b, "**PR:** %s\n", task.SourceURL)
+	fmt.Fprintf(&b, "**Branch:** %s\n", task.Branch)
+	fmt.Fprintf(&b, "**Base:** %s\n", task.BaseBranch)
+	fmt.Fprintf(&b, "**Attempt:** %d of 3\n\n", task.Attempts+1)
+	b.WriteString("## Instructions\n\n")
+	b.WriteString("1. Run `git fetch origin`\n")
+	fmt.Fprintf(&b, "2. Run `git rebase origin/%s`\n", task.BaseBranch)
+	b.WriteString("3. If there are merge conflicts, resolve them carefully — preserve the intent of both sides\n")
+	fmt.Fprintf(&b, "4. Run `git push --force-with-lease origin %s`\n", task.Branch)
+	fmt.Fprintf(&b, "5. Do NOT open a new PR — one already exists at %s\n\n", task.SourceURL)
+	b.WriteString("If the rebase cannot be completed cleanly after your best effort, exit with a non-zero status and print a brief explanation of what conflicted.\n")
+	return []byte(b.String())
 }

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -177,3 +177,84 @@ func TestCopyPersonaFiles_NoCLAUDEMd(t *testing.T) {
 		t.Errorf("unexpected error when CLAUDE.md absent: %v", err)
 	}
 }
+
+func TestBuildRebasePrompt_Format(t *testing.T) {
+	task := &domain.Task{
+		Type:       domain.TaskTypeRebase,
+		Branch:     "feature/my-pr",
+		BaseBranch: "main",
+		SourceURL:  "https://github.com/org/repo/pull/9",
+		Attempts:   1,
+	}
+	prompt := string(buildRebasePrompt(task, ""))
+
+	if !strings.Contains(prompt, "# Task: Rebase `feature/my-pr` onto `main`") {
+		t.Error("missing rebase title")
+	}
+	if !strings.Contains(prompt, "**Attempt:** 2 of 3") {
+		t.Error("expected attempt count 2 (Attempts+1)")
+	}
+	if !strings.Contains(prompt, "git rebase origin/main") {
+		t.Error("missing rebase command")
+	}
+	if !strings.Contains(prompt, "git push --force-with-lease origin feature/my-pr") {
+		t.Error("missing push command")
+	}
+	if !strings.Contains(prompt, "https://github.com/org/repo/pull/9") {
+		t.Error("missing PR URL")
+	}
+}
+
+func TestBuildRebasePrompt_WithWorkflow(t *testing.T) {
+	task := &domain.Task{
+		Type:       domain.TaskTypeRebase,
+		Branch:     "fix/thing",
+		BaseBranch: "main",
+		SourceURL:  "https://github.com/org/repo/pull/3",
+		Attempts:   0,
+	}
+	workflow := "You are rebasing a PR. Be careful."
+	prompt := string(buildRebasePrompt(task, workflow))
+
+	if !strings.HasPrefix(prompt, workflow) {
+		t.Error("workflow should appear at start of prompt")
+	}
+	if !strings.Contains(prompt, "---") {
+		t.Error("expected separator between workflow and task")
+	}
+}
+
+func TestExecute_RebaseTask_TakesRebasePath(t *testing.T) {
+	// We verify that Execute() with a rebase task does NOT fall through to the
+	// issue path by checking it calls executeRebase (which tries git fetch).
+	// Since there's no real git repo in a temp dir, it will fail at that step —
+	// but the error message must reflect the rebase path, not the issue path.
+	repoDir := t.TempDir()
+	sup := New(Config{
+		RepoRoot:       repoDir,
+		WorktreeBaseDir: ".conductor/runs",
+		TimeoutMinutes: 1,
+	})
+	task := &domain.Task{
+		ID:         "pr-99",
+		Type:       domain.TaskTypeRebase,
+		Branch:     "feature/test",
+		BaseBranch: "main",
+	}
+	run := &domain.Run{ID: "test-run", TaskID: task.ID}
+	result := sup.Execute(t.Context(), RunRequest{Run: run, Task: task})
+	if result == nil {
+		t.Fatal("expected a result")
+	}
+	// Should fail in the rebase path (git fetch fails in a non-git temp dir).
+	if result.Err == nil {
+		t.Fatal("expected error (no git repo in temp dir)")
+	}
+	// The error comes from git fetch, not from createWorktree (issue path).
+	// Both produce exec errors, but rebase path says "git fetch".
+	if !strings.Contains(result.Err.Error(), "git fetch") &&
+		!strings.Contains(result.Err.Error(), "fetch") &&
+		!strings.Contains(result.Err.Error(), "create rebase worktree") {
+		t.Errorf("expected rebase-path error, got: %v", result.Err)
+	}
+}

--- a/internal/worksource/github.go
+++ b/internal/worksource/github.go
@@ -2,7 +2,9 @@ package worksource
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -13,8 +15,11 @@ import (
 )
 
 const (
-	claimedLabel = "conductor:claimed"
-	runningLabel = "conductor:running"
+	claimedLabel        = "conductor:claimed"
+	runningLabel        = "conductor:running"
+	rebasingLabel       = "conductor:rebasing"
+	rebaseAbandonedLabel = "conductor:rebase-abandoned"
+	rebaseAttemptsPrefix = "conductor:rebase-attempts-"
 )
 
 // GitHubSource polls a GitHub repository for issues and claims them via labels.
@@ -73,18 +78,25 @@ func (s *GitHubSource) Poll(ctx context.Context) ([]*domain.Task, error) {
 	return tasks, nil
 }
 
-// Claim adds the conductor:claimed label to the issue atomically.
-// If the label was already added by another process the API will succeed but we
-// do a fresh read to verify we were the one to add it (simple optimistic lock).
+// Claim adds the conductor:claimed label to the issue atomically, or
+// conductor:rebasing to the PR for rebase tasks.
 func (s *GitHubSource) Claim(ctx context.Context, task *domain.Task) error {
-	issueNum, err := strconv.Atoi(task.ID)
+	num, err := strconv.Atoi(task.ID)
 	if err != nil {
-		return fmt.Errorf("invalid github issue id %q: %w", task.ID, err)
+		return fmt.Errorf("invalid github id %q: %w", task.ID, err)
 	}
 
-	_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, issueNum, []string{claimedLabel})
+	if task.Type == domain.TaskTypeRebase {
+		_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, num, []string{rebasingLabel})
+		if err != nil {
+			return fmt.Errorf("claim rebase PR #%d: %w", num, err)
+		}
+		return nil
+	}
+
+	_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, num, []string{claimedLabel})
 	if err != nil {
-		return fmt.Errorf("claim issue #%d: %w", issueNum, err)
+		return fmt.Errorf("claim issue #%d: %w", num, err)
 	}
 	return nil
 }
@@ -143,5 +155,160 @@ func issueToTask(issue *gh.Issue, repo string) *domain.Task {
 		CreatedAt:   issue.GetCreatedAt().Time,
 		UpdatedAt:   issue.GetUpdatedAt().Time,
 	}
+}
+
+// ListOpenPRs returns open PRs that are behind their base branch and eligible
+// for an automated rebase. PRs are skipped if they are already claimed
+// (conductor:rebasing), abandoned (conductor:rebase-abandoned), or have
+// exhausted all attempts (conductor:rebase-attempts-3).
+func (s *GitHubSource) ListOpenPRs(ctx context.Context) ([]*domain.Task, error) {
+	opts := &gh.PullRequestListOptions{
+		State: "open",
+		ListOptions: gh.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	prs, _, err := s.client.PullRequests.List(ctx, s.owner, s.repo, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list open PRs: %w", err)
+	}
+
+	var tasks []*domain.Task
+	for _, pr := range prs {
+		if prHasLabel(pr, rebasingLabel) ||
+			prHasLabel(pr, rebaseAbandonedLabel) ||
+			prHasLabel(pr, rebaseAttemptsPrefix+"3") {
+			continue
+		}
+
+		// Check if the PR is behind its base.
+		comparison, _, err := s.client.Repositories.CompareCommits(
+			ctx, s.owner, s.repo,
+			pr.GetBase().GetSHA(),
+			pr.GetHead().GetSHA(),
+			nil,
+		)
+		if err != nil {
+			// Log and skip this PR rather than failing the whole list.
+			continue
+		}
+		if comparison.GetBehindBy() <= 0 {
+			continue
+		}
+
+		attempts := rebaseAttempts(pr)
+		tasks = append(tasks, prToRebaseTask(pr, s.owner+"/"+s.repo, attempts))
+	}
+	return tasks, nil
+}
+
+// RecordRebaseOutcome updates labels and optionally posts a comment after a
+// rebase attempt. On success, removes conductor:rebasing. On failure,
+// increments the attempt counter; after 3 failures adds conductor:rebase-abandoned
+// and posts an abandonment comment.
+func (s *GitHubSource) RecordRebaseOutcome(ctx context.Context, task *domain.Task, succeeded bool, reason string) error {
+	prNum, err := strconv.Atoi(task.ID)
+	if err != nil {
+		return fmt.Errorf("invalid PR id %q: %w", task.ID, err)
+	}
+
+	// Always remove conductor:rebasing.
+	_, err = s.client.Issues.RemoveLabelForIssue(ctx, s.owner, s.repo, prNum, rebasingLabel)
+	if err != nil {
+		// Ignore 404 — label may not be present.
+		if !isNotFound(err) {
+			return fmt.Errorf("remove rebasing label: %w", err)
+		}
+	}
+
+	if succeeded {
+		return nil
+	}
+
+	newAttempts := task.Attempts + 1
+
+	// Remove old attempts label if present, then add the new one.
+	if task.Attempts > 0 {
+		old := rebaseAttemptsPrefix + strconv.Itoa(task.Attempts)
+		_, _ = s.client.Issues.RemoveLabelForIssue(ctx, s.owner, s.repo, prNum, old) //nolint:errcheck
+	}
+	_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, prNum, []string{rebaseAttemptsPrefix + strconv.Itoa(newAttempts)})
+	if err != nil {
+		return fmt.Errorf("add rebase-attempts label: %w", err)
+	}
+
+	if newAttempts >= 3 {
+		_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, prNum, []string{rebaseAbandonedLabel})
+		if err != nil {
+			return fmt.Errorf("add rebase-abandoned label: %w", err)
+		}
+
+		body := fmt.Sprintf("## Conductor: Rebase Abandoned\n\nAfter 3 attempts, the conductor was unable to rebase this branch onto `%s`.\n\n**Last error:** %s\n\nPlease rebase manually and force-push, or close and re-open the PR.",
+			task.BaseBranch, reason)
+		comment := &gh.IssueComment{Body: gh.Ptr(body)}
+		_, _, err = s.client.Issues.CreateComment(ctx, s.owner, s.repo, prNum, comment)
+		if err != nil {
+			return fmt.Errorf("post abandonment comment: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// prHasLabel returns true if the PR has the named label.
+func prHasLabel(pr *gh.PullRequest, name string) bool {
+	for _, l := range pr.Labels {
+		if l.GetName() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// rebaseAttempts returns the current attempt count encoded in PR labels.
+func rebaseAttempts(pr *gh.PullRequest) int {
+	for _, l := range pr.Labels {
+		name := l.GetName()
+		if strings.HasPrefix(name, rebaseAttemptsPrefix) {
+			n, err := strconv.Atoi(strings.TrimPrefix(name, rebaseAttemptsPrefix))
+			if err == nil {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+// prToRebaseTask converts a GitHub PR to a rebase domain.Task.
+func prToRebaseTask(pr *gh.PullRequest, repo string, attempts int) *domain.Task {
+	labels := make([]string, 0, len(pr.Labels))
+	for _, l := range pr.Labels {
+		labels = append(labels, l.GetName())
+	}
+	return &domain.Task{
+		ID:         strconv.Itoa(pr.GetNumber()),
+		Title:      fmt.Sprintf("Rebase #%d: %s", pr.GetNumber(), pr.GetTitle()),
+		Labels:     labels,
+		Status:     domain.TaskStatusPending,
+		Source:     "github",
+		SourceURL:  pr.GetHTMLURL(),
+		Type:       domain.TaskTypeRebase,
+		Branch:     pr.GetHead().GetRef(),
+		BaseBranch: pr.GetBase().GetRef(),
+		Attempts:   attempts,
+	}
+}
+
+// isNotFound returns true if the GitHub API error is a 404.
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errResp *gh.ErrorResponse
+	if errors.As(err, &errResp) {
+		return errResp.Response.StatusCode == http.StatusNotFound
+	}
+	return strings.Contains(err.Error(), "404")
 }
 

--- a/internal/worksource/github_test.go
+++ b/internal/worksource/github_test.go
@@ -1,12 +1,78 @@
 package worksource
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	gh "github.com/google/go-github/v68/github"
+	"golang.org/x/oauth2"
 
 	"github.com/haha-systems/conductor/internal/domain"
 )
+
+// newTestGitHubSource creates a GitHubSource pointed at a test HTTP server.
+// The mux should NOT register a catch-all handler — this function adds one
+// that returns a proper JSON 404 so that go-github can parse it as ErrorResponse.
+func newTestGitHubSource(t *testing.T, mux *http.ServeMux) *GitHubSource {
+	t.Helper()
+
+	// Catch-all: return a JSON 404 for any unregistered path so go-github can
+	// parse it as a *gh.ErrorResponse (the default HTML 404 breaks errors.As).
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found","documentation_url":""}`)) //nolint:errcheck
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"})
+	tc := oauth2.NewClient(context.Background(), ts)
+	client := gh.NewClient(tc)
+	// Point the client at our test server.
+	baseURL := srv.URL + "/"
+	client.BaseURL, _ = client.BaseURL.Parse(baseURL)
+
+	return &GitHubSource{
+		client: client,
+		owner:  "org",
+		repo:   "repo",
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v) //nolint:errcheck
+}
+
+// --- helper PR builder ---
+
+func makePR(num int, head, base string, labels ...string) map[string]any {
+	lbls := make([]map[string]any, len(labels))
+	for i, l := range labels {
+		lbls[i] = map[string]any{"name": l}
+	}
+	return map[string]any{
+		"number":   num,
+		"title":    fmt.Sprintf("PR %d", num),
+		"html_url": fmt.Sprintf("https://github.com/org/repo/pull/%d", num),
+		"head": map[string]any{
+			"sha": head,
+			"ref": fmt.Sprintf("feature/pr-%d", num),
+		},
+		"base": map[string]any{
+			"sha": base,
+			"ref": "main",
+		},
+		"labels": lbls,
+	}
+}
 
 func TestNewGitHubSource_InvalidRepo(t *testing.T) {
 	cases := []string{"", "noslash", "/nope", "nope/"}
@@ -63,6 +129,296 @@ func TestMatchesFilter(t *testing.T) {
 	}
 	if s.matchesFilter(issueMissing) {
 		t.Error("expected matchesFilter to return false when label missing")
+	}
+}
+
+// --- ListOpenPRs tests ---
+
+func TestListOpenPRs_BehindBase(t *testing.T) {
+	mux := http.NewServeMux()
+	// Return one PR that is behind base.
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(7, "headSHA", "baseSHA")})
+	})
+	// CompareCommits: head is 1 behind base.
+	mux.HandleFunc("/repos/org/repo/compare/baseSHA...headSHA", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{"behind_by": 1, "ahead_by": 2})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListOpenPRs(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	task := tasks[0]
+	if task.Type != domain.TaskTypeRebase {
+		t.Errorf("expected type=rebase, got %q", task.Type)
+	}
+	if task.ID != "7" {
+		t.Errorf("expected ID=7, got %q", task.ID)
+	}
+	if task.BaseBranch != "main" {
+		t.Errorf("expected BaseBranch=main, got %q", task.BaseBranch)
+	}
+}
+
+func TestListOpenPRs_NotBehind_Excluded(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(8, "headSHA", "baseSHA")})
+	})
+	// behind_by = 0 — not behind.
+	mux.HandleFunc("/repos/org/repo/compare/baseSHA...headSHA", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{"behind_by": 0, "ahead_by": 1})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListOpenPRs(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for up-to-date PR, got %d", len(tasks))
+	}
+}
+
+func TestListOpenPRs_ExcludesAbandoned(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(9, "headSHA", "baseSHA", rebaseAbandonedLabel)})
+	})
+	// CompareCommits should never be called for abandoned PR.
+	mux.HandleFunc("/repos/org/repo/compare/", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("CompareCommits should not be called for abandoned PR")
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListOpenPRs(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for abandoned PR, got %d", len(tasks))
+	}
+}
+
+func TestListOpenPRs_ExcludesRebasing(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(10, "headSHA", "baseSHA", rebasingLabel)})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListOpenPRs(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for PR already being rebased, got %d", len(tasks))
+	}
+}
+
+func TestListOpenPRs_ExcludesThreeAttempts(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(11, "headSHA", "baseSHA", rebaseAttemptsPrefix+"3")})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListOpenPRs(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for PR with 3 attempts, got %d", len(tasks))
+	}
+}
+
+func TestListOpenPRs_ParsesAttempts(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(12, "headSHA", "baseSHA", rebaseAttemptsPrefix+"2")})
+	})
+	mux.HandleFunc("/repos/org/repo/compare/baseSHA...headSHA", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{"behind_by": 1, "ahead_by": 0})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListOpenPRs(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].Attempts != 2 {
+		t.Errorf("expected Attempts=2, got %d", tasks[0].Attempts)
+	}
+}
+
+// --- RecordRebaseOutcome tests ---
+
+func TestRecordRebaseOutcome_Success(t *testing.T) {
+	var deletedPaths []string
+	mux := http.NewServeMux()
+	// Handle all label operations under issue 5 with trailing-slash prefix match.
+	mux.HandleFunc("/repos/org/repo/issues/5/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deletedPaths = append(deletedPaths, r.URL.Path)
+			writeJSON(w, []any{})
+			return
+		}
+		writeJSON(w, []any{})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	task := &domain.Task{ID: "5", Type: domain.TaskTypeRebase, BaseBranch: "main", Attempts: 0}
+	err := s.RecordRebaseOutcome(context.Background(), task, true, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// At least one DELETE should have been made to remove the rebasing label.
+	if len(deletedPaths) == 0 {
+		t.Errorf("expected at least one DELETE for rebasing label removal")
+	}
+}
+
+func TestRecordRebaseOutcome_FirstFailure(t *testing.T) {
+	var addedLabels []string
+	mux := http.NewServeMux()
+	// Handle all issue 5 label operations.
+	mux.HandleFunc("/repos/org/repo/issues/5/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			writeJSON(w, []any{})
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels") {
+			// go-github sends labels as a raw JSON array ["label1", "label2"]
+			var labels []string
+			json.NewDecoder(r.Body).Decode(&labels) //nolint:errcheck
+			addedLabels = append(addedLabels, labels...)
+			writeJSON(w, []any{})
+			return
+		}
+		writeJSON(w, []any{})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	task := &domain.Task{ID: "5", Type: domain.TaskTypeRebase, BaseBranch: "main", Attempts: 0}
+	err := s.RecordRebaseOutcome(context.Background(), task, false, "conflict in foo.go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(addedLabels) == 0 {
+		t.Fatal("expected a label to be added")
+	}
+	if addedLabels[0] != rebaseAttemptsPrefix+"1" {
+		t.Errorf("expected label %q, got %q", rebaseAttemptsPrefix+"1", addedLabels[0])
+	}
+}
+
+func TestRecordRebaseOutcome_ThirdFailure_PostsComment(t *testing.T) {
+	var commentBody string
+	var addedLabels []string
+	mux := http.NewServeMux()
+
+	// Handle all label operations and comments under issue 5.
+	mux.HandleFunc("/repos/org/repo/issues/5/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete:
+			writeJSON(w, []any{})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			// go-github sends labels as a raw JSON array ["label1", "label2"]
+			var labels []string
+			json.NewDecoder(r.Body).Decode(&labels) //nolint:errcheck
+			addedLabels = append(addedLabels, labels...)
+			writeJSON(w, []any{})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			var body struct {
+				Body string `json:"body"`
+			}
+			json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+			commentBody = body.Body
+			writeJSON(w, map[string]any{"id": 1})
+		default:
+			writeJSON(w, []any{})
+		}
+	})
+
+	s := newTestGitHubSource(t, mux)
+	task := &domain.Task{ID: "5", Type: domain.TaskTypeRebase, BaseBranch: "main", Attempts: 2}
+	err := s.RecordRebaseOutcome(context.Background(), task, false, "unresolvable conflict")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hasAttempts3 := false
+	hasAbandoned := false
+	for _, l := range addedLabels {
+		if l == rebaseAttemptsPrefix+"3" {
+			hasAttempts3 = true
+		}
+		if l == rebaseAbandonedLabel {
+			hasAbandoned = true
+		}
+	}
+	if !hasAttempts3 {
+		t.Errorf("expected label %q to be added, got %v", rebaseAttemptsPrefix+"3", addedLabels)
+	}
+	if !hasAbandoned {
+		t.Errorf("expected label %q to be added, got %v", rebaseAbandonedLabel, addedLabels)
+	}
+	if !strings.Contains(commentBody, "Rebase Abandoned") {
+		t.Errorf("expected abandonment comment, got %q", commentBody)
+	}
+	if !strings.Contains(commentBody, "main") {
+		t.Errorf("expected base branch in comment, got %q", commentBody)
+	}
+	if !strings.Contains(commentBody, "unresolvable conflict") {
+		t.Errorf("expected error reason in comment, got %q", commentBody)
+	}
+}
+
+// --- helper label tests ---
+
+func TestPrHasLabel(t *testing.T) {
+	pr := &gh.PullRequest{
+		Labels: []*gh.Label{
+			{Name: gh.Ptr("conductor:rebasing")},
+		},
+	}
+	if !prHasLabel(pr, "conductor:rebasing") {
+		t.Error("expected prHasLabel to return true")
+	}
+	if prHasLabel(pr, "conductor:rebase-abandoned") {
+		t.Error("expected prHasLabel to return false for absent label")
+	}
+}
+
+func TestRebaseAttempts_Parsing(t *testing.T) {
+	cases := []struct {
+		labels   []string
+		expected int
+	}{
+		{nil, 0},
+		{[]string{"conductor:rebase-attempts-1"}, 1},
+		{[]string{"conductor:rebase-attempts-2"}, 2},
+		{[]string{"other-label"}, 0},
+	}
+	for _, tc := range cases {
+		lbls := make([]*gh.Label, len(tc.labels))
+		for i, l := range tc.labels {
+			l := l
+			lbls[i] = &gh.Label{Name: &l}
+		}
+		pr := &gh.PullRequest{Labels: lbls}
+		got := rebaseAttempts(pr)
+		if got != tc.expected {
+			t.Errorf("labels=%v: expected %d attempts, got %d", tc.labels, tc.expected, got)
+		}
 	}
 }
 

--- a/internal/worksource/linear.go
+++ b/internal/worksource/linear.go
@@ -135,6 +135,16 @@ mutation($issueId: String!, $labelId: String!) {
 	return nil
 }
 
+// ListOpenPRs returns nil for Linear — PR rebase detection is not supported.
+func (s *LinearSource) ListOpenPRs(_ context.Context) ([]*domain.Task, error) {
+	return nil, nil
+}
+
+// RecordRebaseOutcome is a no-op for Linear — PR rebase detection is not supported.
+func (s *LinearSource) RecordRebaseOutcome(_ context.Context, _ *domain.Task, _ bool, _ string) error {
+	return nil
+}
+
 // PostResult adds a comment to the Linear issue.
 func (s *LinearSource) PostResult(ctx context.Context, task *domain.Task, summary string) error {
 	mutation := `

--- a/internal/worksource/poller.go
+++ b/internal/worksource/poller.go
@@ -70,11 +70,17 @@ func (p *TaskPoller) Done() {
 }
 
 func (p *TaskPoller) poll(ctx context.Context, out chan<- *domain.Task) {
-	tasks, err := p.source.Poll(ctx)
+	issueTasks, err := p.source.Poll(ctx)
 	if err != nil {
 		slog.Error("poll failed", "source", p.source.Name(), "error", err)
-		return
 	}
+
+	prTasks, err := p.source.ListOpenPRs(ctx)
+	if err != nil {
+		slog.Error("list open PRs failed", "source", p.source.Name(), "error", err)
+	}
+
+	tasks := append(issueTasks, prTasks...)
 
 	for _, task := range tasks {
 		if !p.tryAcquireSlot() {

--- a/internal/worksource/poller_test.go
+++ b/internal/worksource/poller_test.go
@@ -14,6 +14,7 @@ import (
 // mockSource is a controllable WorkSource for testing.
 type mockSource struct {
 	tasks     []*domain.Task
+	prTasks   []*domain.Task
 	claimErr  error
 	pollCount atomic.Int32
 	claimed   []string
@@ -38,6 +39,14 @@ func (m *mockSource) Claim(_ context.Context, task *domain.Task) error {
 }
 
 func (m *mockSource) PostResult(_ context.Context, _ *domain.Task, _ string) error {
+	return nil
+}
+
+func (m *mockSource) ListOpenPRs(_ context.Context) ([]*domain.Task, error) {
+	return m.prTasks, nil
+}
+
+func (m *mockSource) RecordRebaseOutcome(_ context.Context, _ *domain.Task, _ bool, _ string) error {
 	return nil
 }
 
@@ -100,6 +109,45 @@ func TestPoller_BackPressure(t *testing.T) {
 	cancel()
 	// Drain
 	for range ch {
+	}
+}
+
+func TestPoller_RebaseAndIssueTasks_BothFlow(t *testing.T) {
+	issueTasks := makeTasks("issue-1")
+	prTask := &domain.Task{
+		ID:     "pr-1",
+		Status: domain.TaskStatusPending,
+		Type:   domain.TaskTypeRebase,
+	}
+	src := &mockSource{
+		tasks:   issueTasks,
+		prTasks: []*domain.Task{prTask},
+	}
+	p := NewPoller(src, PollerConfig{IntervalSeconds: 60, MaxConcurrentRuns: 4})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ch := p.Run(ctx)
+	var received []*domain.Task
+	for task := range ch {
+		received = append(received, task)
+		p.Done()
+		if len(received) == 2 {
+			cancel()
+		}
+	}
+
+	if len(received) != 2 {
+		t.Fatalf("expected 2 tasks (1 issue + 1 rebase), got %d", len(received))
+	}
+
+	types := map[domain.TaskType]bool{}
+	for _, task := range received {
+		types[task.Type] = true
+	}
+	if !types[domain.TaskTypeRebase] {
+		t.Error("expected a rebase task to flow through the poller")
 	}
 }
 

--- a/internal/worksource/worksource.go
+++ b/internal/worksource/worksource.go
@@ -17,4 +17,12 @@ type WorkSource interface {
 	Claim(ctx context.Context, task *domain.Task) error
 	// PostResult posts a proof summary comment back to the originating task/issue.
 	PostResult(ctx context.Context, task *domain.Task, summary string) error
+	// ListOpenPRs returns open PRs that are behind their base branch and
+	// eligible for an automated rebase (not already claimed or abandoned).
+	ListOpenPRs(ctx context.Context) ([]*domain.Task, error)
+	// RecordRebaseOutcome updates the source system after a rebase attempt.
+	// On success, removes the in-progress marker. On failure, increments the
+	// attempt counter and, after 3 failures, marks the PR as abandoned and
+	// posts a comment explaining why.
+	RecordRebaseOutcome(ctx context.Context, task *domain.Task, succeeded bool, reason string) error
 }


### PR DESCRIPTION
## Summary

- Adds `TaskType` (`issue`/`rebase`) and rebase-specific fields (`Branch`, `BaseBranch`, `Attempts`) to `domain.Task` — fully backward compatible (zero value treated as issue)
- Extends `WorkSource` interface with `ListOpenPRs` and `RecordRebaseOutcome`; GitHub implementation detects PRs behind base via `CompareCommits` and manages `conductor:rebasing`, `conductor:rebase-attempts-N`, `conductor:rebase-abandoned` labels with an abandonment comment after 3 failures; Linear gets no-op stubs
- `TaskPoller.poll()` now merges issue and PR tasks into one queue — one concurrency budget, no new polling interval
- `Supervisor.executeRebase()` fetches the PR branch into a dedicated worktree, builds a structured rebase prompt (with optional `.conductor/REBASE_WORKFLOW.md` prefix), runs the agent, and records the outcome via the new `RebaseRecorder` interface
- Full test coverage: domain type tests, GitHub unit tests using `httptest` (filtering, label management, abandonment comment), poller flow test, supervisor prompt format and type-branching tests

## Test plan

- [x] `go test ./...` passes
- [x] PR 1 commit behind `main` appears in `ListOpenPRs` (unit test with mock HTTP)
- [x] PR labelled `conductor:rebase-abandoned` excluded from `ListOpenPRs`
- [x] `RecordRebaseOutcome(false, ...)` on 3rd attempt posts abandonment comment and adds `conductor:rebase-abandoned` (unit test)
- [x] `Execute()` with rebase task calls `executeRebase()` path, not issue path (unit test)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)