### PR TITLE
fix: use branch ref instead of stale SHA in ListOpenPRs

### DIFF
--- a/internal/worksource/github.go
+++ b/internal/worksource/github.go
@@ -185,7 +185,7 @@ func (s *GitHubSource) ListOpenPRs(ctx context.Context) ([]*domain.Task, error) 
 		// Check if the PR is behind its base.
 		comparison, _, err := s.client.Repositories.CompareCommits(
 			ctx, s.owner, s.repo,
-			pr.GetBase().GetSHA(),
+			pr.GetBase().GetRef(), // branch name resolves to current HEAD at query time
 			pr.GetHead().GetSHA(),
 			nil,
 		)

--- a/internal/worksource/github_test.go
+++ b/internal/worksource/github_test.go
@@ -140,8 +140,8 @@ func TestListOpenPRs_BehindBase(t *testing.T) {
 	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, []any{makePR(7, "headSHA", "baseSHA")})
 	})
-	// CompareCommits: head is 1 behind base.
-	mux.HandleFunc("/repos/org/repo/compare/baseSHA...headSHA", func(w http.ResponseWriter, r *http.Request) {
+	// CompareCommits: head is 1 behind base (using branch ref "main").
+	mux.HandleFunc("/repos/org/repo/compare/main...headSHA", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]any{"behind_by": 1, "ahead_by": 2})
 	})
 
@@ -171,7 +171,7 @@ func TestListOpenPRs_NotBehind_Excluded(t *testing.T) {
 		writeJSON(w, []any{makePR(8, "headSHA", "baseSHA")})
 	})
 	// behind_by = 0 — not behind.
-	mux.HandleFunc("/repos/org/repo/compare/baseSHA...headSHA", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/org/repo/compare/main...headSHA", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]any{"behind_by": 0, "ahead_by": 1})
 	})
 
@@ -242,7 +242,7 @@ func TestListOpenPRs_ParsesAttempts(t *testing.T) {
 	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, []any{makePR(12, "headSHA", "baseSHA", rebaseAttemptsPrefix+"2")})
 	})
-	mux.HandleFunc("/repos/org/repo/compare/baseSHA...headSHA", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/org/repo/compare/main...headSHA", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]any{"behind_by": 1, "ahead_by": 0})
 	})
 


### PR DESCRIPTION
Closes #14

## Problem

`ListOpenPRs` compared against `pr.GetBase().GetSHA()` — the base branch SHA captured when the PR was opened. After new commits land on `main`, this SHA goes stale and `CompareCommits` returns `behind_by = 0`, so the PR is always skipped.

## Fix

Replace `GetSHA()` with `GetRef()` (returns `"main"` or whichever branch name). GitHub resolves branch refs to the live HEAD at query time, so `behind_by` correctly reflects commits added after the PR was created.

## Tests

Updated three test handlers in `github_test.go` to expect the compare URL with `main...headSHA` instead of `baseSHA...headSHA`, matching the new behaviour.