### PR TITLE
fix: remove conductor:rebasing label on all executeRebase failure paths

### DIFF
--- a/cmd/conductor/main.go
+++ b/cmd/conductor/main.go
@@ -340,7 +340,9 @@ func executeRun(
 	})
 	if result.Err != nil {
 		log.Error("run failed", "run_id", run.ID, "error", result.Err)
-		if task.Type != domain.TaskTypeRebase {
+		if task.Type == domain.TaskTypeRebase {
+			source.RecordRebaseOutcome(ctx, task, false, result.Err.Error()) //nolint:errcheck
+		} else {
 			source.PostResult(ctx, task, fmt.Sprintf("Run failed: %v", result.Err)) //nolint:errcheck
 		}
 		return

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -413,11 +413,13 @@ func (s *Supervisor) executeRebase(ctx context.Context, req RunRequest) *Result 
 	fetchCmd := exec.Command("git", "fetch", "origin")
 	fetchCmd.Dir = s.cfg.RepoRoot
 	if out, err := fetchCmd.CombinedOutput(); err != nil {
+		s.recordRebaseOutcome(ctx, req, false, err.Error())
 		return s.fail(run, fmt.Errorf("git fetch: %w: %s", err, out))
 	}
 
 	// Create worktree with the PR branch checked out.
 	if err := s.createRebaseBranchWorktree(worktreePath, req.Task.Branch); err != nil {
+		s.recordRebaseOutcome(ctx, req, false, err.Error())
 		return s.fail(run, fmt.Errorf("create rebase worktree: %w", err))
 	}
 
@@ -426,18 +428,21 @@ func (s *Supervisor) executeRebase(ctx context.Context, req RunRequest) *Result 
 	prompt := buildRebasePrompt(req.Task, workflow)
 	taskFile := filepath.Join(worktreePath, ".conductor-task.md")
 	if err := os.WriteFile(taskFile, prompt, 0600); err != nil {
+		s.recordRebaseOutcome(ctx, req, false, err.Error())
 		s.cleanup(run)
 		return s.fail(run, fmt.Errorf("write task file: %w", err))
 	}
 
 	// Open run log.
 	if err := os.MkdirAll(filepath.Join(worktreePath, "proof"), 0755); err != nil {
+		s.recordRebaseOutcome(ctx, req, false, err.Error())
 		s.cleanup(run)
 		return s.fail(run, fmt.Errorf("create proof dir: %w", err))
 	}
 	logPath := filepath.Join(worktreePath, "run.jsonl")
 	logFile, err := os.Create(logPath)
 	if err != nil {
+		s.recordRebaseOutcome(ctx, req, false, err.Error())
 		s.cleanup(run)
 		return s.fail(run, fmt.Errorf("create run log: %w", err))
 	}


### PR DESCRIPTION
Closes #18

## Summary

- In `executeRebase` (supervisor.go), adds `recordRebaseOutcome(false, ...)` before each early-exit `s.fail(...)` call: git fetch failure, worktree creation failure, task file write failure, proof dir creation failure, and run log creation failure.
- In `executeRun` (main.go), calls `source.RecordRebaseOutcome` when a rebase task returns an error, replacing the previous no-op branch that skipped all handling for rebase failures.

## Test plan
- [x] `go test ./...` passes
- [x] All early-exit paths in `executeRebase` now call `recordRebaseOutcome` before returning
- [x] `executeRun` calls `RecordRebaseOutcome` on rebase task failure (belt-and-suspenders; safe because `RecordRebaseOutcome` ignores 404 on label removal)