### PR TITLE
docs: add CONTRIBUTING.md, .conductor/ directory reference, and release checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,15 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist/
+      - name: Generate checksums
+        run: |
+          cd dist
+          find . -type f | sort | xargs sha256sum > sha256sums.txt
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           generate_release_notes: true
-          files: dist/**/*
+          files: |
+            dist/**/*
+            dist/sha256sums.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to Conductor
+
+## Running the tests
+
+```bash
+go test ./...
+go test -race ./...
+```
+
+## Branch naming
+
+Follow the existing convention:
+
+| Prefix   | Use for                          |
+|----------|----------------------------------|
+| `feat/`  | New features                     |
+| `fix/`   | Bug fixes                        |
+| `ci/`    | CI / workflow changes            |
+| `chore/` | Maintenance, deps, docs, cleanup |
+
+## Pull request process
+
+1. Fork the repo and create a branch from `main` using the naming convention above.
+2. Make your changes and ensure `go test ./...` passes.
+3. Open a PR against `main` — CI runs tests and a build check automatically.
+4. A maintainer will review and merge once CI is green.
+
+## Adding a new provider
+
+1. Create a file in `internal/provider/` (e.g. `myprovider.go`).
+2. Implement the `AgentProvider` interface defined in `internal/provider/provider.go`.
+3. Register the provider in `buildProviders` in `cmd/conductor/main.go`.
+4. Add an entry to the Providers table in `README.md`.
+
+## Adding a new work source
+
+1. Create a file in `internal/worksource/` (e.g. `myplatform.go`).
+2. Implement the `WorkSource` interface defined in `internal/worksource/worksource.go`.
+3. Register the source in `buildWorkSource` in `cmd/conductor/main.go`.
+4. Add configuration documentation to `README.md` under **Work sources**.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,30 @@ After a successful run, Conductor writes a `proof/summary.json` file inside the 
 
 Use `conductor land --run-id <id>` to rebase the worktree branch on `main`, wait for CI to pass, and merge automatically.
 
+## `.conductor/` directory structure
+
+Conductor looks for several files inside a `.conductor/` directory at the root of your repo. None are required, but they let you customise how agents behave.
+
+| Path | Purpose |
+|------|---------|
+| `.conductor/WORKFLOW.md` | Injected at the top of every task prompt — use for global agent instructions |
+| `.conductor/REBASE_WORKFLOW.md` | Injected into rebase task prompts (optional, falls back to none) |
+| `.conductor/personas/<name>/` | Persona directory — see Personas section |
+| `.conductor/personas/<name>/SOUL.md` | Core identity injected as the Role section of the task prompt |
+| `.conductor/personas/<name>/PERSONALITY.md` | Behavioral traits appended to the Role section |
+| `.conductor/personas/<name>/CLAUDE.md` | Copied to the worktree root before the agent runs |
+| `.conductor/personas/<name>/AGENTS.md` | Replaces `WORKFLOW.md` for this persona |
+| `.conductor/personas/<name>/persona.toml` | Optional: `provider = "claude"` to override the default provider |
+| `.conductor/runs/` | Auto-managed run worktrees (configured via `worktree_dir`) |
+
+The `workflow_file` and `worktree_dir` config keys control which paths Conductor uses:
+
+```toml
+[sandbox]
+worktree_dir  = ".conductor/runs"
+workflow_file = ".conductor/WORKFLOW.md"
+```
+
 ## License
 
 Apache 2.0


### PR DESCRIPTION
Closes #26

## Summary

- **CONTRIBUTING.md** — new file covering how to run tests (`go test ./...` and `-race`), branch naming convention, PR process, and step-by-step instructions for adding a new provider or work source
- **README** — new `.conductor/ directory structure` section explaining `WORKFLOW.md`, `REBASE_WORKFLOW.md`, the `personas/` layout, and `runs/`
- **Release workflow** — adds a `Generate checksums` step that produces `sha256sums.txt` in `dist/` and includes it in the GitHub Release alongside the binaries

## Test plan
- [x] `go test ./...` passes
- [x] `CONTRIBUTING.md` exists at repo root
- [x] README contains `.conductor/ directory structure` section with the full table
- [x] `release.yml` generates and uploads `sha256sums.txt`