### PR TITLE
fix: populate CostUSD via provider CostEstimate

### DIFF
--- a/cmd/conductor/main.go
+++ b/cmd/conductor/main.go
@@ -318,7 +318,7 @@ func executeRace(
 	}
 
 	log.Info("race winner", "provider", winnerProvider.Name(), "run_id", winner.Run.ID, "failures", failures)
-	finishRun(ctx, winner.Run, task, collector, source, hooks, log)
+	finishRun(ctx, winner.Run, task, winnerProvider, collector, source, hooks, log)
 }
 
 func executeRun(
@@ -352,13 +352,14 @@ func executeRun(
 	if task.Type == domain.TaskTypeRebase {
 		return // outcome already recorded by supervisor via RecordRebaseOutcome
 	}
-	finishRun(ctx, run, task, collector, source, hooks, log)
+	finishRun(ctx, run, task, p, collector, source, hooks, log)
 }
 
 func finishRun(
 	ctx context.Context,
 	run *domain.Run,
 	task *domain.Task,
+	p provider.AgentProvider,
 	collector *proof.Collector,
 	source worksource.WorkSource,
 	hooks []string,
@@ -366,7 +367,7 @@ func finishRun(
 ) {
 	log.Info("run succeeded", "run_id", run.ID)
 
-	bundle, err := collector.Collect(ctx, run, task)
+	bundle, err := collector.Collect(ctx, run, task, p)
 	if err != nil {
 		log.Error("proof collection failed", "run_id", run.ID, "error", err)
 		source.PostResult(ctx, task, fmt.Sprintf("Run succeeded but proof collection failed: %v", err)) //nolint:errcheck

--- a/internal/proof/collector.go
+++ b/internal/proof/collector.go
@@ -15,6 +15,11 @@ import (
 	"github.com/haha-systems/conductor/internal/domain"
 )
 
+// CostEstimator is implemented by provider adapters that can estimate run cost.
+type CostEstimator interface {
+	CostEstimate(promptLen int) (float64, bool)
+}
+
 // Config controls what proof collection does.
 type Config struct {
 	RequireCIPass bool
@@ -34,7 +39,8 @@ func New(cfg Config) *Collector {
 
 // Collect runs CI, computes diff stats, optionally opens a PR, and writes
 // proof/summary.json into the run's worktree. It returns the ProofBundle.
-func (c *Collector) Collect(ctx context.Context, run *domain.Run, task *domain.Task) (*domain.ProofBundle, error) {
+// provider may be nil; if non-nil and able to estimate cost, CostUSD is populated.
+func (c *Collector) Collect(ctx context.Context, run *domain.Run, task *domain.Task, provider CostEstimator) (*domain.ProofBundle, error) {
 	started := time.Now()
 
 	bundle := &domain.ProofBundle{
@@ -65,10 +71,19 @@ func (c *Collector) Collect(ctx context.Context, run *domain.Run, task *domain.T
 		bundle.DurationSeconds = time.Since(started).Seconds()
 	}
 
-	// 4. Merge agent-written metadata (pr_url, walkthrough, etc.).
+	// 4. Cost estimate from provider (best-effort; zero if not available).
+	if provider != nil {
+		if promptData, err := os.ReadFile(filepath.Join(run.WorktreePath, ".conductor-task.md")); err == nil {
+			if cost, ok := provider.CostEstimate(len(promptData)); ok {
+				bundle.CostUSD = cost
+			}
+		}
+	}
+
+	// 5. Merge agent-written metadata (pr_url, walkthrough, etc.).
 	readAgentMetadata(run.WorktreePath, bundle)
 
-	// 5. Write summary.json.
+	// 6. Write summary.json.
 	summaryPath := filepath.Join(run.WorktreePath, "proof", "summary.json")
 	if err := writeSummary(summaryPath, bundle); err != nil {
 		return nil, fmt.Errorf("write summary: %w", err)

--- a/internal/proof/collector_test.go
+++ b/internal/proof/collector_test.go
@@ -1,9 +1,13 @@
 package proof
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/haha-systems/conductor/internal/domain"
 )
 
 func TestParseShortstat(t *testing.T) {
@@ -60,5 +64,124 @@ func TestInferCICommand_Unknown(t *testing.T) {
 	cmd := inferCICommand(t.TempDir())
 	if cmd != nil {
 		t.Errorf("expected nil for unknown repo type, got %v", cmd)
+	}
+}
+
+// stubEstimator is a test double for CostEstimator.
+type stubEstimator struct {
+	rate float64 // USD per 1k tokens; 0 means no estimate
+}
+
+func (s *stubEstimator) CostEstimate(promptLen int) (float64, bool) {
+	if s.rate <= 0 {
+		return 0, false
+	}
+	tokens := float64(promptLen) / 4.0
+	return (tokens / 1000.0) * s.rate, true
+}
+
+func TestCollect_CostUSD_WithRate(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a fake .conductor-task.md (4000 bytes → 1000 tokens).
+	prompt := make([]byte, 4000)
+	for i := range prompt {
+		prompt[i] = 'x'
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".conductor-task.md"), prompt, 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Create proof/ dir so writeSummary can write.
+	if err := os.MkdirAll(filepath.Join(dir, "proof"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	run := &domain.Run{
+		ID:           "r1",
+		TaskID:       "t1",
+		Provider:     "claude",
+		WorktreePath: dir,
+		StartedAt:    now,
+		FinishedAt:   &now,
+	}
+	task := &domain.Task{ID: "t1"}
+
+	c := New(Config{CICommand: []string{"true"}})
+	// rate = $1.00 per 1k tokens; 1000 tokens → $1.00
+	est := &stubEstimator{rate: 1.0}
+
+	bundle, err := c.Collect(context.Background(), run, task, est)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if bundle.CostUSD == 0 {
+		t.Error("expected CostUSD > 0 when provider has a rate, got 0")
+	}
+	// 4000 bytes / 4 = 1000 tokens; 1000/1000 * $1.00 = $1.00
+	const want = 1.0
+	if bundle.CostUSD != want {
+		t.Errorf("CostUSD = %f, want %f", bundle.CostUSD, want)
+	}
+}
+
+func TestCollect_CostUSD_NoRate(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".conductor-task.md"), []byte("task"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "proof"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	run := &domain.Run{
+		ID:           "r2",
+		TaskID:       "t2",
+		Provider:     "codex",
+		WorktreePath: dir,
+		StartedAt:    now,
+		FinishedAt:   &now,
+	}
+	task := &domain.Task{ID: "t2"}
+
+	c := New(Config{CICommand: []string{"true"}})
+	// rate = 0 → no estimate
+	est := &stubEstimator{rate: 0}
+
+	bundle, err := c.Collect(context.Background(), run, task, est)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if bundle.CostUSD != 0 {
+		t.Errorf("expected CostUSD = 0 for provider with no rate, got %f", bundle.CostUSD)
+	}
+}
+
+func TestCollect_CostUSD_NilProvider(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "proof"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	run := &domain.Run{
+		ID:           "r3",
+		TaskID:       "t3",
+		Provider:     "shell",
+		WorktreePath: dir,
+		StartedAt:    now,
+		FinishedAt:   &now,
+	}
+	task := &domain.Task{ID: "t3"}
+
+	c := New(Config{CICommand: []string{"true"}})
+
+	bundle, err := c.Collect(context.Background(), run, task, nil)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if bundle.CostUSD != 0 {
+		t.Errorf("expected CostUSD = 0 with nil provider, got %f", bundle.CostUSD)
 	}
 }


### PR DESCRIPTION
## Summary

- Define a `CostEstimator` interface in the `proof` package with a single `CostEstimate(promptLen int) (float64, bool)` method
- Thread the provider through `finishRun` → `Collector.Collect` so cost estimation is available at proof collection time
- Read `.conductor-task.md` in `Collect` to get the prompt length, then call `CostEstimate` to populate `bundle.CostUSD`
- Providers with no configured rate (e.g. Codex) return `(0, false)` — `CostUSD` stays `0.0` without error
- `nil` provider is handled gracefully (no panic)

## Test plan
- [x] `TestCollect_CostUSD_WithRate` — verifies non-zero cost when provider has a rate (4000-byte prompt at $1.00/1k tokens = $1.00)
- [x] `TestCollect_CostUSD_NoRate` — verifies `CostUSD = 0` when provider returns `(0, false)`
- [x] `TestCollect_CostUSD_NilProvider` — verifies no panic when provider is nil
- [x] `go test ./...` passes

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)