### PR TITLE
fix: remove race condition on extraArgs mutation in custom adapter

### DIFF
--- a/internal/provider/custom.go
+++ b/internal/provider/custom.go
@@ -36,17 +36,15 @@ func (a *CustomAdapter) Run(ctx context.Context, rc RunContext) (RunHandle, erro
 	if a.shell.binary == "" {
 		return nil, fmt.Errorf("custom adapter %q: binary must be set", a.shell.name)
 	}
-	// Substitute template variables in extra args.
+	// Substitute template variables in extra args. Use a local copy of the
+	// shellAdapter so we never mutate the shared struct (race condition).
 	resolved := make([]string, len(a.shell.extraArgs))
 	for i, arg := range a.shell.extraArgs {
 		resolved[i] = applyTemplates(arg, rc)
 	}
-	// Temporarily replace extraArgs, run, then restore.
-	orig := a.shell.extraArgs
-	a.shell.extraArgs = resolved
-	handle, err := a.shell.adapterRun(ctx, rc)
-	a.shell.extraArgs = orig
-	return handle, err
+	local := a.shell
+	local.extraArgs = resolved
+	return local.adapterRun(ctx, rc)
 }
 
 func applyTemplates(s string, rc RunContext) string {


### PR DESCRIPTION
## Summary

- Replaces the save/restore mutation pattern in `customAdapter.Run` with a local copy of `shellAdapter`
- The local copy gets `extraArgs` set to the resolved (template-substituted) args, leaving the shared struct untouched
- This eliminates the data race that occurs when `executeRace` spawns N concurrent goroutines sharing the same `CustomAdapter`

## Why the suggested `prependArgs` approach wouldn't work

`adapterRunWithStdin` does `args := append(prependArgs, a.extraArgs...)`, so passing resolved args as `prependArgs` would concatenate them with the original unresolved `extraArgs`, producing incorrect doubled arguments. The local-copy approach correctly replaces `extraArgs` for the duration of each call without touching shared state.

Closes #25