### PR TITLE
chore: rename conductor.toml to conductor.toml.example and gitignore live config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 /conductor
 .conductor/runs/
+conductor.toml

--- a/conductor.toml.example
+++ b/conductor.toml.example
@@ -4,7 +4,7 @@ default_provider = "claude"
 work_interval_seconds = 30
 
 [work_sources.github]
-repo = "haha-systems/conductor"
+repo = "your-org/your-repo"
 label_filter = ["conductor"]
 
 [providers.claude]


### PR DESCRIPTION
## Summary

- Renames `conductor.toml` → `conductor.toml.example` with placeholder values (repo changed from `haha-systems/conductor` to `your-org/your-repo`) so cloners don't accidentally poll the upstream repo
- Adds `conductor.toml` to `.gitignore` so the live config is never accidentally committed
- The README already documents `cp conductor.toml.example conductor.toml` so no README changes needed

## Verification

- [x] `conductor.toml` is listed in `.gitignore`
- [x] `conductor.toml.example` exists at the repo root with placeholder values
- [x] `conductor.toml` does not exist in the repository (`git ls-files conductor.toml` returns empty)

Closes #23