### PR TITLE
feat: QA review loop — conductor:qa-engineer persona reviews and iterates on PRs before merge

### DIFF
--- a/.conductor/personas/qa-engineer/AGENTS.md
+++ b/.conductor/personas/qa-engineer/AGENTS.md
@@ -1,0 +1,9 @@
+You are performing a code review. You have access to the `gh` CLI for reading PR diffs and posting reviews.
+
+Your only tools are:
+- `gh pr diff <N>` — read the implementation
+- `gh pr view <N>` — read PR metadata
+- `gh pr review <N> --approve --body "..."` — approve
+- `gh pr review <N> --request-changes --body "..."` — request changes
+
+Do not write or modify any code. Do not run tests. Read the spec, read the diff, make a decision, post the review, exit.

--- a/.conductor/personas/qa-engineer/SOUL.md
+++ b/.conductor/personas/qa-engineer/SOUL.md
@@ -1,0 +1,5 @@
+You are a rigorous QA engineer reviewing pull requests for a coding agent orchestration system.
+
+Your job is to verify that implementations fully satisfy their specifications. You are thorough but fair — you only request changes for genuine spec gaps, missing functionality, or bugs. You never request stylistic changes, formatting improvements, or unsolicited refactoring.
+
+When you approve, you write a brief, confident summary of what you verified. When you request changes, you write a specific, numbered list of what is missing or wrong, with enough detail that the implementing agent can address each point without ambiguity.

--- a/cmd/conductor/main.go
+++ b/cmd/conductor/main.go
@@ -286,11 +286,12 @@ func executeRace(
 		go func() {
 			run := &domain.Run{ID: newRunID(), TaskID: task.ID, Provider: p.Name()}
 			result := sup.Execute(raceCtx, supervisor.RunRequest{
-				Run:      run,
-				Task:     task,
-				Provider: p,
-				Persona:  route.Persona,
-				Source:   source,
+				Run:          run,
+				Task:         task,
+				Provider:     p,
+				Persona:      route.Persona,
+				Source:       source,
+				ReviewSource: source,
 			})
 			ch <- outcome{result: result, p: p}
 		}()
@@ -334,22 +335,29 @@ func executeRun(
 ) {
 	run := &domain.Run{ID: newRunID(), TaskID: task.ID, Provider: p.Name()}
 	result := sup.Execute(ctx, supervisor.RunRequest{
-		Run:      run,
-		Task:     task,
-		Provider: p,
-		Persona:  persona,
-		Source:   source,
+		Run:          run,
+		Task:         task,
+		Provider:     p,
+		Persona:      persona,
+		Source:       source,
+		ReviewSource: source,
 	})
 	if result.Err != nil {
 		log.Error("run failed", "run_id", run.ID, "error", result.Err)
-		if task.Type == domain.TaskTypeRebase {
+		switch task.Type {
+		case domain.TaskTypeReview, domain.TaskTypeRevise:
+			source.RecordReviewOutcome(ctx, task, false, result.Err.Error()) //nolint:errcheck
+		case domain.TaskTypeRebase:
 			source.RecordRebaseOutcome(ctx, task, false, result.Err.Error()) //nolint:errcheck
-		} else {
+		default:
 			source.PostResult(ctx, task, fmt.Sprintf("Run failed: %v", result.Err)) //nolint:errcheck
 		}
 		return
 	}
-	if task.Type == domain.TaskTypeRebase {
+	switch task.Type {
+	case domain.TaskTypeReview, domain.TaskTypeRevise:
+		return // outcome already recorded by supervisor
+	case domain.TaskTypeRebase:
 		return // outcome already recorded by supervisor via RecordRebaseOutcome
 	}
 	finishRun(ctx, run, task, p, collector, source, hooks, log)
@@ -367,7 +375,7 @@ func finishRun(
 ) {
 	log.Info("run succeeded", "run_id", run.ID)
 
-	bundle, err := collector.Collect(ctx, run, task, p)
+	bundle, err := collector.Collect(ctx, run, task, p, source)
 	if err != nil {
 		log.Error("proof collection failed", "run_id", run.ID, "error", err)
 		source.PostResult(ctx, task, fmt.Sprintf("Run succeeded but proof collection failed: %v", err)) //nolint:errcheck

--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -28,6 +28,10 @@ const (
 	TaskTypeIssue TaskType = "issue"
 	// TaskTypeRebase is a task to rebase a PR branch onto its base branch.
 	TaskTypeRebase TaskType = "rebase"
+	// TaskTypeReview is a task for the QA persona to review a PR against its spec.
+	TaskTypeReview TaskType = "review"
+	// TaskTypeRevise is a task for the implementing agent to address QA feedback.
+	TaskTypeRevise TaskType = "revise"
 )
 
 // TaskConfig holds the optional conductor: front-matter parsed from a task description.
@@ -59,6 +63,12 @@ type Task struct {
 	BaseBranch string
 	// Attempts is the number of rebase attempts already recorded by the WorkSource.
 	Attempts int
+	// ReviewCycle is the QA review cycle number (1, 2, 3). Only used for
+	// TaskTypeReview and TaskTypeRevise tasks.
+	ReviewCycle int
+	// SpecIssueNumber is the originating issue number for review/revise tasks.
+	// Zero for TaskTypeIssue and TaskTypeRebase tasks.
+	SpecIssueNumber int
 }
 
 // frontMatterMarker is the YAML front-matter delimiter.

--- a/internal/domain/task_test.go
+++ b/internal/domain/task_test.go
@@ -86,10 +86,53 @@ func TestTaskType_DefaultIsIssue(t *testing.T) {
 	if TaskTypeRebase != "rebase" {
 		t.Errorf("expected TaskTypeRebase=\"rebase\", got %q", TaskTypeRebase)
 	}
+	if TaskTypeReview != "review" {
+		t.Errorf("expected TaskTypeReview=\"review\", got %q", TaskTypeReview)
+	}
+	if TaskTypeRevise != "revise" {
+		t.Errorf("expected TaskTypeRevise=\"revise\", got %q", TaskTypeRevise)
+	}
 	// A task constructed without setting Type has the zero value (empty string),
 	// which should be treated as issue by callers.
 	if task.Type == TaskTypeRebase {
 		t.Error("zero-value task should not be treated as rebase")
+	}
+}
+
+func TestTask_ReviewFields(t *testing.T) {
+	task := &Task{
+		ID:              "7",
+		Type:            TaskTypeReview,
+		SourceURL:       "https://github.com/org/repo/pull/7",
+		Branch:          "feat/my-feature",
+		ReviewCycle:     1,
+		SpecIssueNumber: 42,
+	}
+	if task.ReviewCycle != 1 {
+		t.Errorf("expected ReviewCycle=1, got %d", task.ReviewCycle)
+	}
+	if task.SpecIssueNumber != 42 {
+		t.Errorf("expected SpecIssueNumber=42, got %d", task.SpecIssueNumber)
+	}
+	if task.Type != TaskTypeReview {
+		t.Errorf("expected type=review, got %q", task.Type)
+	}
+}
+
+func TestTask_ReviseFields(t *testing.T) {
+	task := &Task{
+		ID:              "7",
+		Type:            TaskTypeRevise,
+		SourceURL:       "https://github.com/org/repo/pull/7",
+		Branch:          "feat/my-feature",
+		ReviewCycle:     2,
+		SpecIssueNumber: 42,
+	}
+	if task.Type != TaskTypeRevise {
+		t.Errorf("expected type=revise, got %q", task.Type)
+	}
+	if task.ReviewCycle != 2 {
+		t.Errorf("expected ReviewCycle=2, got %d", task.ReviewCycle)
 	}
 }
 

--- a/internal/proof/collector.go
+++ b/internal/proof/collector.go
@@ -20,6 +20,11 @@ type CostEstimator interface {
 	CostEstimate(promptLen int) (float64, bool)
 }
 
+// ReviewNotifier is implemented by work sources that can mark a PR as needing review.
+type ReviewNotifier interface {
+	MarkPRNeedsReview(ctx context.Context, prNumber int, issueNumber int) error
+}
+
 // Config controls what proof collection does.
 type Config struct {
 	RequireCIPass bool
@@ -40,7 +45,8 @@ func New(cfg Config) *Collector {
 // Collect runs CI, computes diff stats, optionally opens a PR, and writes
 // proof/summary.json into the run's worktree. It returns the ProofBundle.
 // provider may be nil; if non-nil and able to estimate cost, CostUSD is populated.
-func (c *Collector) Collect(ctx context.Context, run *domain.Run, task *domain.Task, provider CostEstimator) (*domain.ProofBundle, error) {
+// notifier may be nil; if non-nil and the bundle has a PRUrl, MarkPRNeedsReview is called.
+func (c *Collector) Collect(ctx context.Context, run *domain.Run, task *domain.Task, provider CostEstimator, notifier ReviewNotifier) (*domain.ProofBundle, error) {
 	started := time.Now()
 
 	bundle := &domain.ProofBundle{
@@ -82,6 +88,15 @@ func (c *Collector) Collect(ctx context.Context, run *domain.Run, task *domain.T
 
 	// 5. Merge agent-written metadata (pr_url, walkthrough, etc.).
 	readAgentMetadata(run.WorktreePath, bundle)
+
+	// 5a. If a PR was opened, mark it as needing QA review.
+	if bundle.PRUrl != "" && notifier != nil {
+		prNum := parsePRNumber(bundle.PRUrl)
+		issueNum, _ := strconv.Atoi(task.ID)
+		if prNum > 0 && issueNum > 0 {
+			notifier.MarkPRNeedsReview(ctx, prNum, issueNum) //nolint:errcheck
+		}
+	}
 
 	// 6. Write summary.json.
 	summaryPath := filepath.Join(run.WorktreePath, "proof", "summary.json")
@@ -234,4 +249,18 @@ func writeSummary(path string, bundle *domain.ProofBundle) error {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// parsePRNumber extracts the PR number from a GitHub PR URL.
+// e.g. "https://github.com/org/repo/pull/42" -> 42
+func parsePRNumber(prURL string) int {
+	parts := strings.Split(prURL, "/pull/")
+	if len(parts) != 2 {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimRight(parts[1], "/"))
+	if err != nil {
+		return 0
+	}
+	return n
 }

--- a/internal/proof/collector_test.go
+++ b/internal/proof/collector_test.go
@@ -111,7 +111,7 @@ func TestCollect_CostUSD_WithRate(t *testing.T) {
 	// rate = $1.00 per 1k tokens; 1000 tokens → $1.00
 	est := &stubEstimator{rate: 1.0}
 
-	bundle, err := c.Collect(context.Background(), run, task, est)
+	bundle, err := c.Collect(context.Background(), run, task, est, nil)
 	if err != nil {
 		t.Fatalf("Collect: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestCollect_CostUSD_NoRate(t *testing.T) {
 	// rate = 0 → no estimate
 	est := &stubEstimator{rate: 0}
 
-	bundle, err := c.Collect(context.Background(), run, task, est)
+	bundle, err := c.Collect(context.Background(), run, task, est, nil)
 	if err != nil {
 		t.Fatalf("Collect: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestCollect_CostUSD_NilProvider(t *testing.T) {
 
 	c := New(Config{CICommand: []string{"true"}})
 
-	bundle, err := c.Collect(context.Background(), run, task, nil)
+	bundle, err := c.Collect(context.Background(), run, task, nil, nil)
 	if err != nil {
 		t.Fatalf("Collect: %v", err)
 	}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,6 +23,13 @@ type RebaseRecorder interface {
 	RecordRebaseOutcome(ctx context.Context, task *domain.Task, succeeded bool, reason string) error
 }
 
+// ReviewRecorder is satisfied by any WorkSource that supports QA review outcome
+// recording. It is used by the supervisor without importing the worksource package.
+type ReviewRecorder interface {
+	RecordReviewOutcome(ctx context.Context, task *domain.Task, approved bool, body string) error
+	MarkPRNeedsReview(ctx context.Context, prNumber int, issueNumber int) error
+}
+
 // RunRequest is submitted to the supervisor to start a run.
 type RunRequest struct {
 	Run      *domain.Run
@@ -33,6 +41,8 @@ type RunRequest struct {
 	Persona *config.PersonaConfig
 	// Source is used by rebase tasks to record outcomes. Nil is safe for issue tasks.
 	Source RebaseRecorder
+	// ReviewSource is used by review/revise tasks to record outcomes. Nil is safe for other task types.
+	ReviewSource ReviewRecorder
 }
 
 // Result is returned by the supervisor after a run terminates.
@@ -64,8 +74,13 @@ func New(cfg Config) *Supervisor {
 // Execute runs the task synchronously and returns when the run reaches a terminal state.
 // The caller is responsible for collecting proof afterwards.
 func (s *Supervisor) Execute(ctx context.Context, req RunRequest) *Result {
-	if req.Task.Type == domain.TaskTypeRebase {
+	switch req.Task.Type {
+	case domain.TaskTypeRebase:
 		return s.executeRebase(ctx, req)
+	case domain.TaskTypeReview:
+		return s.executeReview(ctx, req)
+	case domain.TaskTypeRevise:
+		return s.executeRevise(ctx, req)
 	}
 
 	run := req.Run
@@ -512,6 +527,353 @@ func (s *Supervisor) executeRebase(ctx context.Context, req RunRequest) *Result 
 		s.cleanup(run)
 	}
 	return &Result{Run: run}
+}
+
+// executeReview handles a TaskTypeReview run: the QA agent reads the PR diff
+// and posts an approval or change-request review via the gh CLI.
+// No worktree is needed — the agent runs from the repo root.
+func (s *Supervisor) executeReview(ctx context.Context, req RunRequest) *Result {
+	run := req.Run
+	now := time.Now()
+	run.StartedAt = now
+	run.Status = domain.RunStatusRunning
+	run.WorktreePath = s.cfg.RepoRoot
+
+	// Build review prompt.
+	prompt, err := s.buildReviewPrompt(ctx, req.Task)
+	if err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("build review prompt: %w", err))
+	}
+
+	// Write prompt to a temp file in the repo root.
+	taskFile := filepath.Join(s.cfg.RepoRoot, ".conductor-review-"+run.ID+".md")
+	if err := os.WriteFile(taskFile, prompt, 0600); err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("write review prompt: %w", err))
+	}
+	defer os.Remove(taskFile) //nolint:errcheck
+
+	// Open run log.
+	logPath := filepath.Join(s.cfg.RepoRoot, "run.jsonl")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("open run log: %w", err))
+	}
+	defer logFile.Close()
+
+	logWriter := &providerLogWriter{w: logFile}
+
+	// Apply timeout.
+	timeout := time.Duration(s.cfg.TimeoutMinutes) * time.Minute
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	rc := provider.RunContext{
+		RepoPath:       s.cfg.RepoRoot,
+		TaskFile:       taskFile,
+		Env:            env,
+		LogWriter:      logWriter,
+		TimeoutSeconds: int(timeout.Seconds()),
+	}
+
+	logEvent(logFile, "run_started", map[string]any{
+		"run_id":  run.ID,
+		"task_id": run.TaskID,
+		"type":    "review",
+		"pr":      req.Task.SourceURL,
+	})
+
+	handle, err := req.Provider.Run(runCtx, rc)
+	if err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("launch provider: %w", err))
+	}
+
+	waitErr := handle.Wait()
+	finished := time.Now()
+	run.FinishedAt = &finished
+
+	if runCtx.Err() == context.DeadlineExceeded {
+		run.Status = domain.RunStatusTimeout
+		reason := fmt.Sprintf("review timed out after %d minutes", s.cfg.TimeoutMinutes)
+		logEvent(logFile, "run_timeout", map[string]any{"run_id": run.ID})
+		s.recordReviewOutcome(ctx, req, false, reason)
+		return &Result{Run: run, Err: fmt.Errorf("%s", reason)}
+	}
+
+	if waitErr != nil {
+		run.Status = domain.RunStatusFailed
+		run.ErrorMsg = waitErr.Error()
+		logEvent(logFile, "run_failed", map[string]any{"run_id": run.ID, "error": waitErr.Error()})
+		s.recordReviewOutcome(ctx, req, false, waitErr.Error())
+		return &Result{Run: run, Err: waitErr}
+	}
+
+	run.Status = domain.RunStatusSucceeded
+	logEvent(logFile, "run_succeeded", map[string]any{"run_id": run.ID})
+	// Agent exit 0 means it approved via gh pr review --approve.
+	s.recordReviewOutcome(ctx, req, true, "")
+	return &Result{Run: run}
+}
+
+// executeRevise handles a TaskTypeRevise run: the implementing agent addresses
+// QA feedback and pushes to the existing PR branch.
+func (s *Supervisor) executeRevise(ctx context.Context, req RunRequest) *Result {
+	run := req.Run
+	now := time.Now()
+	run.StartedAt = now
+	run.Status = domain.RunStatusRunning
+
+	worktreePath := filepath.Join(s.cfg.RepoRoot, s.cfg.WorktreeBaseDir, run.ID)
+	run.WorktreePath = worktreePath
+
+	// Fetch so origin/<branch> is current.
+	fetchCmd := exec.Command("git", "fetch", "origin")
+	fetchCmd.Dir = s.cfg.RepoRoot
+	if out, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
+		s.recordReviewOutcome(ctx, req, false, fetchErr.Error())
+		return s.fail(run, fmt.Errorf("git fetch: %w: %s", fetchErr, out))
+	}
+
+	// Create worktree with the PR branch checked out.
+	if err := s.createRebaseBranchWorktree(worktreePath, req.Task.Branch); err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("create revise worktree: %w", err))
+	}
+
+	// Build revision prompt.
+	prompt, err := s.buildRevisionPrompt(ctx, req.Task)
+	if err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("build revision prompt: %w", err))
+	}
+	taskFile := filepath.Join(worktreePath, ".conductor-task.md")
+	if err := os.WriteFile(taskFile, prompt, 0600); err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("write task file: %w", err))
+	}
+
+	// Open run log.
+	if err := os.MkdirAll(filepath.Join(worktreePath, "proof"), 0755); err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("create proof dir: %w", err))
+	}
+	logPath := filepath.Join(worktreePath, "run.jsonl")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("create run log: %w", err))
+	}
+	defer logFile.Close()
+
+	logWriter := &providerLogWriter{w: logFile}
+
+	// Apply timeout.
+	timeout := time.Duration(s.cfg.TimeoutMinutes) * time.Minute
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	rc := provider.RunContext{
+		RepoPath:       worktreePath,
+		TaskFile:       taskFile,
+		Env:            env,
+		LogWriter:      logWriter,
+		TimeoutSeconds: int(timeout.Seconds()),
+	}
+
+	logEvent(logFile, "run_started", map[string]any{
+		"run_id":  run.ID,
+		"task_id": run.TaskID,
+		"type":    "revise",
+		"branch":  req.Task.Branch,
+	})
+
+	handle, err := req.Provider.Run(runCtx, rc)
+	if err != nil {
+		s.cleanup(run)
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("launch provider: %w", err))
+	}
+
+	waitErr := handle.Wait()
+	finished := time.Now()
+	run.FinishedAt = &finished
+
+	if runCtx.Err() == context.DeadlineExceeded {
+		run.Status = domain.RunStatusTimeout
+		reason := fmt.Sprintf("revise timed out after %d minutes", s.cfg.TimeoutMinutes)
+		logEvent(logFile, "run_timeout", map[string]any{"run_id": run.ID})
+		s.recordReviewOutcome(ctx, req, false, reason)
+		if !s.cfg.PreserveOnFailure {
+			s.cleanup(run)
+		}
+		return &Result{Run: run, Err: fmt.Errorf("%s", reason)}
+	}
+
+	if waitErr != nil {
+		run.Status = domain.RunStatusFailed
+		run.ErrorMsg = waitErr.Error()
+		logEvent(logFile, "run_failed", map[string]any{"run_id": run.ID, "error": waitErr.Error()})
+		s.recordReviewOutcome(ctx, req, false, "revision agent failed: "+waitErr.Error())
+		if !s.cfg.PreserveOnFailure {
+			s.cleanup(run)
+		}
+		return &Result{Run: run, Err: waitErr}
+	}
+
+	run.Status = domain.RunStatusSucceeded
+	logEvent(logFile, "run_succeeded", map[string]any{"run_id": run.ID})
+
+	// On success, re-trigger QA review.
+	if req.ReviewSource != nil {
+		prNum, err := strconv.Atoi(req.Task.ID)
+		if err == nil {
+			req.ReviewSource.MarkPRNeedsReview(ctx, prNum, req.Task.SpecIssueNumber) //nolint:errcheck
+		}
+	}
+
+	if !s.cfg.PreserveOnFailure {
+		s.cleanup(run)
+	}
+	return &Result{Run: run}
+}
+
+func (s *Supervisor) recordReviewOutcome(ctx context.Context, req RunRequest, approved bool, reason string) {
+	if req.ReviewSource == nil {
+		return
+	}
+	req.ReviewSource.RecordReviewOutcome(ctx, req.Task, approved, reason) //nolint:errcheck
+}
+
+// buildReviewPrompt builds the review task prompt for the QA agent.
+func (s *Supervisor) buildReviewPrompt(ctx context.Context, task *domain.Task) ([]byte, error) {
+	var b strings.Builder
+
+	// Load QA persona AGENTS.md if present.
+	agentsPath := filepath.Join(s.cfg.RepoRoot, ".conductor", "personas", "qa-engineer", "AGENTS.md")
+	if data, err := os.ReadFile(agentsPath); err == nil {
+		b.WriteString(string(data))
+		b.WriteString("\n\n---\n\n")
+	}
+
+	prNum := task.ID
+	cycle := task.ReviewCycle
+
+	fmt.Fprintf(&b, "# Task: Review PR #%s — cycle %d of 3\n\n", prNum, cycle)
+	fmt.Fprintf(&b, "**PR:** %s\n", task.SourceURL)
+	fmt.Fprintf(&b, "**Branch:** %s\n", task.Branch)
+	fmt.Fprintf(&b, "**Original issue:** #%d\n\n", task.SpecIssueNumber)
+
+	// Fetch original issue body.
+	issueBody := s.fetchIssueBody(ctx, task)
+	b.WriteString("## Original Spec\n\n")
+	b.WriteString(issueBody)
+	b.WriteString("\n\n")
+
+	b.WriteString("## Instructions\n\n")
+	fmt.Fprintf(&b, "1. Run `gh pr diff %s` to read the full implementation diff\n", prNum)
+	b.WriteString("2. Verify that every requirement in the spec above is satisfied by the implementation\n")
+	b.WriteString("3. Check for obvious bugs or spec gaps — do NOT flag style issues or unsolicited improvements\n")
+	b.WriteString("4. If the implementation is complete and correct:\n")
+	fmt.Fprintf(&b, "   `gh pr review %s --approve --body \"<brief approval summary>\"`\n", prNum)
+	b.WriteString("5. If there are genuine gaps or bugs:\n")
+	fmt.Fprintf(&b, "   `gh pr review %s --request-changes --body \"<specific, actionable list of what is missing or wrong>\"`\n\n", prNum)
+	b.WriteString("Exit 0 after posting your review. Do not make any code changes.\n")
+
+	return []byte(b.String()), nil
+}
+
+// buildRevisionPrompt builds the revision task prompt for the implementing agent.
+func (s *Supervisor) buildRevisionPrompt(ctx context.Context, task *domain.Task) ([]byte, error) {
+	var b strings.Builder
+
+	// Load default workflow or persona AGENTS.md.
+	workflow := s.loadWorkflow(nil)
+	if workflow != "" {
+		b.WriteString(workflow)
+		b.WriteString("\n\n---\n\n")
+	}
+
+	prNum := task.ID
+	cycle := task.ReviewCycle
+
+	fmt.Fprintf(&b, "# Task: Address QA feedback on PR #%s — cycle %d of 3\n\n", prNum, cycle)
+	fmt.Fprintf(&b, "**PR:** %s\n", task.SourceURL)
+	fmt.Fprintf(&b, "**Branch:** %s\n\n", task.Branch)
+
+	// Fetch original issue body.
+	issueBody := s.fetchIssueBody(ctx, task)
+	fmt.Fprintf(&b, "## Original Spec (Issue #%d)\n\n", task.SpecIssueNumber)
+	b.WriteString(issueBody)
+	b.WriteString("\n\n")
+
+	// Fetch QA feedback from PR comments.
+	prComments := s.fetchPRComments(ctx, task)
+	b.WriteString("## QA Feedback\n\n")
+	b.WriteString(prComments)
+	b.WriteString("\n\n")
+
+	b.WriteString("## Instructions\n\n")
+	b.WriteString("1. Read the QA feedback carefully\n")
+	b.WriteString("2. Make all necessary changes to address every point raised\n")
+	fmt.Fprintf(&b, "3. `git add -A && git commit -m \"address QA feedback (cycle %d)\"`\n", cycle)
+	fmt.Fprintf(&b, "4. `git push origin %s`\n\n", task.Branch)
+	b.WriteString("Do not open a new PR — push to the existing branch. Do not address anything not mentioned in the QA feedback.\n")
+
+	return []byte(b.String()), nil
+}
+
+// fetchIssueBody fetches the body of the original spec issue via the gh CLI.
+// Returns a placeholder string on error rather than failing the prompt build.
+func (s *Supervisor) fetchIssueBody(ctx context.Context, task *domain.Task) string {
+	if task.SpecIssueNumber == 0 {
+		return "(original issue body unavailable)"
+	}
+	repoSlug := extractRepoSlug(task.SourceURL)
+	if repoSlug == "" {
+		return "(original issue body unavailable)"
+	}
+	out, err := exec.CommandContext(ctx, "gh", "api",
+		fmt.Sprintf("repos/%s/issues/%d", repoSlug, task.SpecIssueNumber),
+		"--jq", ".body",
+	).Output()
+	if err != nil {
+		return "(could not fetch issue body)"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// fetchPRComments fetches review comments from the PR via the gh CLI.
+func (s *Supervisor) fetchPRComments(ctx context.Context, task *domain.Task) string {
+	out, err := exec.CommandContext(ctx, "gh", "pr", "view", task.ID, "--comments").Output()
+	if err != nil {
+		return "(could not fetch PR comments)"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// extractRepoSlug extracts "owner/repo" from a GitHub PR or issue URL.
+// e.g. "https://github.com/org/repo/pull/7" -> "org/repo"
+func extractRepoSlug(sourceURL string) string {
+	// Strip scheme and host.
+	const prefix = "https://github.com/"
+	if !strings.HasPrefix(sourceURL, prefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(sourceURL, prefix)
+	parts := strings.SplitN(rest, "/", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
 }
 
 func (s *Supervisor) recordRebaseOutcome(ctx context.Context, req RunRequest, succeeded bool, reason string) {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -224,6 +224,138 @@ func TestBuildRebasePrompt_WithWorkflow(t *testing.T) {
 	}
 }
 
+func TestBuildReviewPrompt_Format(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Create QA persona AGENTS.md
+	personasDir := filepath.Join(repoDir, ".conductor", "personas", "qa-engineer")
+	os.MkdirAll(personasDir, 0755) //nolint:errcheck
+	os.WriteFile(filepath.Join(personasDir, "AGENTS.md"), []byte("You are a QA reviewer."), 0644) //nolint:errcheck
+
+	sup := &Supervisor{cfg: Config{RepoRoot: repoDir, TimeoutMinutes: 5}}
+	task := &domain.Task{
+		ID:              "7",
+		Type:            domain.TaskTypeReview,
+		SourceURL:       "https://github.com/org/repo/pull/7",
+		Branch:          "feat/my-feature",
+		ReviewCycle:     1,
+		SpecIssueNumber: 42,
+	}
+
+	prompt, err := sup.buildReviewPrompt(t.Context(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s := string(prompt)
+
+	if !strings.Contains(s, "You are a QA reviewer.") {
+		t.Error("missing QA AGENTS.md content")
+	}
+	if !strings.Contains(s, "# Task: Review PR #7 — cycle 1 of 3") {
+		t.Error("missing review task title")
+	}
+	if !strings.Contains(s, "**PR:** https://github.com/org/repo/pull/7") {
+		t.Error("missing PR URL")
+	}
+	if !strings.Contains(s, "**Branch:** feat/my-feature") {
+		t.Error("missing branch")
+	}
+	if !strings.Contains(s, "**Original issue:** #42") {
+		t.Error("missing original issue number")
+	}
+	if !strings.Contains(s, "gh pr diff 7") {
+		t.Error("missing gh pr diff instruction")
+	}
+	if !strings.Contains(s, "gh pr review 7 --approve") {
+		t.Error("missing approve instruction")
+	}
+	if !strings.Contains(s, "gh pr review 7 --request-changes") {
+		t.Error("missing request-changes instruction")
+	}
+}
+
+func TestBuildReviewPrompt_NoPersonaFile(t *testing.T) {
+	repoDir := t.TempDir() // no qa-engineer persona
+
+	sup := &Supervisor{cfg: Config{RepoRoot: repoDir, TimeoutMinutes: 5}}
+	task := &domain.Task{
+		ID:              "7",
+		Type:            domain.TaskTypeReview,
+		SourceURL:       "https://github.com/org/repo/pull/7",
+		Branch:          "feat/my-feature",
+		ReviewCycle:     0,
+		SpecIssueNumber: 42,
+	}
+
+	prompt, err := sup.buildReviewPrompt(t.Context(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(prompt), "# Task: Review PR #7") {
+		t.Error("missing review task title when no persona file")
+	}
+}
+
+func TestBuildRevisionPrompt_Format(t *testing.T) {
+	repoDir := t.TempDir()
+
+	sup := &Supervisor{cfg: Config{RepoRoot: repoDir, TimeoutMinutes: 5}}
+	task := &domain.Task{
+		ID:              "7",
+		Type:            domain.TaskTypeRevise,
+		SourceURL:       "https://github.com/org/repo/pull/7",
+		Branch:          "feat/my-feature",
+		ReviewCycle:     1,
+		SpecIssueNumber: 42,
+	}
+
+	prompt, err := sup.buildRevisionPrompt(t.Context(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s := string(prompt)
+
+	if !strings.Contains(s, "# Task: Address QA feedback on PR #7 — cycle 1 of 3") {
+		t.Error("missing revision task title")
+	}
+	if !strings.Contains(s, "**PR:** https://github.com/org/repo/pull/7") {
+		t.Error("missing PR URL")
+	}
+	if !strings.Contains(s, "**Branch:** feat/my-feature") {
+		t.Error("missing branch")
+	}
+	if !strings.Contains(s, "## Original Spec (Issue #42)") {
+		t.Error("missing original spec section")
+	}
+	if !strings.Contains(s, "## QA Feedback") {
+		t.Error("missing QA Feedback section")
+	}
+	if !strings.Contains(s, "address QA feedback (cycle 1)") {
+		t.Error("missing commit message with cycle number")
+	}
+	if !strings.Contains(s, "git push origin feat/my-feature") {
+		t.Error("missing push instruction")
+	}
+}
+
+func TestExtractRepoSlug(t *testing.T) {
+	cases := []struct {
+		url      string
+		expected string
+	}{
+		{"https://github.com/org/repo/pull/7", "org/repo"},
+		{"https://github.com/my-org/my-repo/issues/42", "my-org/my-repo"},
+		{"https://notgithub.com/org/repo/pull/1", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := extractRepoSlug(tc.url)
+		if got != tc.expected {
+			t.Errorf("extractRepoSlug(%q) = %q, want %q", tc.url, got, tc.expected)
+		}
+	}
+}
+
 func TestExecute_RebaseTask_TakesRebasePath(t *testing.T) {
 	// We verify that Execute() with a rebase task does NOT fall through to the
 	// issue path by checking it calls executeRebase (which tries git fetch).

--- a/internal/worksource/github.go
+++ b/internal/worksource/github.go
@@ -15,11 +15,20 @@ import (
 )
 
 const (
-	claimedLabel        = "conductor:claimed"
-	runningLabel        = "conductor:running"
-	rebasingLabel       = "conductor:rebasing"
+	claimedLabel         = "conductor:claimed"
+	runningLabel         = "conductor:running"
+	rebasingLabel        = "conductor:rebasing"
 	rebaseAbandonedLabel = "conductor:rebase-abandoned"
 	rebaseAttemptsPrefix = "conductor:rebase-attempts-"
+
+	needsReviewLabel     = "conductor:needs-review"
+	reviewingLabel       = "conductor:reviewing"
+	needsRevisionLabel   = "conductor:needs-revision"
+	revisingLabel        = "conductor:revising"
+	approvedLabel        = "conductor:approved"
+	reviewAbandonedLabel = "conductor:review-abandoned"
+	reviewCyclePrefix    = "conductor:review-cycle-"
+	issueRefPrefix       = "conductor:issue-"
 )
 
 // GitHubSource polls a GitHub repository for issues and claims them via labels.
@@ -86,10 +95,27 @@ func (s *GitHubSource) Claim(ctx context.Context, task *domain.Task) error {
 		return fmt.Errorf("invalid github id %q: %w", task.ID, err)
 	}
 
-	if task.Type == domain.TaskTypeRebase {
+	switch task.Type {
+	case domain.TaskTypeRebase:
 		_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, num, []string{rebasingLabel})
 		if err != nil {
 			return fmt.Errorf("claim rebase PR #%d: %w", num, err)
+		}
+		return nil
+	case domain.TaskTypeReview:
+		_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, num, []string{reviewingLabel})
+		if err != nil {
+			return fmt.Errorf("claim review PR #%d: %w", num, err)
+		}
+		return nil
+	case domain.TaskTypeRevise:
+		_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, num, []string{revisingLabel})
+		if err != nil {
+			return fmt.Errorf("claim revise PR #%d: %w", num, err)
+		}
+		_, err = s.client.Issues.RemoveLabelForIssue(ctx, s.owner, s.repo, num, needsRevisionLabel)
+		if err != nil && !isNotFound(err) {
+			return fmt.Errorf("remove needs-revision label #%d: %w", num, err)
 		}
 		return nil
 	}
@@ -254,6 +280,205 @@ func (s *GitHubSource) RecordRebaseOutcome(ctx context.Context, task *domain.Tas
 	}
 
 	return nil
+}
+
+// MarkPRNeedsReview adds conductor:needs-review to the PR and records the
+// originating issue number as a conductor:issue-N label.
+func (s *GitHubSource) MarkPRNeedsReview(ctx context.Context, prNumber int, issueNumber int) error {
+	labels := []string{needsReviewLabel, issueRefPrefix + strconv.Itoa(issueNumber)}
+	_, _, err := s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, prNumber, labels)
+	if err != nil {
+		return fmt.Errorf("mark PR #%d needs-review: %w", prNumber, err)
+	}
+	return nil
+}
+
+// ListPRsNeedingReview returns open PRs labelled conductor:needs-review that
+// are not currently being reviewed or in a terminal state.
+func (s *GitHubSource) ListPRsNeedingReview(ctx context.Context) ([]*domain.Task, error) {
+	opts := &gh.PullRequestListOptions{
+		State: "open",
+		ListOptions: gh.ListOptions{PerPage: 100},
+	}
+	prs, _, err := s.client.PullRequests.List(ctx, s.owner, s.repo, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list PRs needing review: %w", err)
+	}
+
+	var tasks []*domain.Task
+	for _, pr := range prs {
+		if !prHasLabel(pr, needsReviewLabel) {
+			continue
+		}
+		if prHasLabel(pr, reviewingLabel) ||
+			prHasLabel(pr, reviewAbandonedLabel) ||
+			prHasLabel(pr, approvedLabel) {
+			continue
+		}
+		tasks = append(tasks, prToReviewTask(pr, s.owner+"/"+s.repo))
+	}
+	return tasks, nil
+}
+
+// ListPRsNeedingRevision returns open PRs labelled conductor:needs-revision
+// that are not already being revised or in a terminal state.
+func (s *GitHubSource) ListPRsNeedingRevision(ctx context.Context) ([]*domain.Task, error) {
+	opts := &gh.PullRequestListOptions{
+		State: "open",
+		ListOptions: gh.ListOptions{PerPage: 100},
+	}
+	prs, _, err := s.client.PullRequests.List(ctx, s.owner, s.repo, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list PRs needing revision: %w", err)
+	}
+
+	var tasks []*domain.Task
+	for _, pr := range prs {
+		if !prHasLabel(pr, needsRevisionLabel) {
+			continue
+		}
+		if prHasLabel(pr, revisingLabel) || prHasLabel(pr, reviewAbandonedLabel) {
+			continue
+		}
+		tasks = append(tasks, prToReviseTask(pr, s.owner+"/"+s.repo))
+	}
+	return tasks, nil
+}
+
+// RecordReviewOutcome updates labels after a QA review completes.
+func (s *GitHubSource) RecordReviewOutcome(ctx context.Context, task *domain.Task, approved bool, body string) error {
+	prNum, err := strconv.Atoi(task.ID)
+	if err != nil {
+		return fmt.Errorf("invalid PR id %q: %w", task.ID, err)
+	}
+
+	// Always remove conductor:reviewing.
+	_, err = s.client.Issues.RemoveLabelForIssue(ctx, s.owner, s.repo, prNum, reviewingLabel)
+	if err != nil && !isNotFound(err) {
+		return fmt.Errorf("remove reviewing label: %w", err)
+	}
+
+	// Always remove conductor:needs-review.
+	_, err = s.client.Issues.RemoveLabelForIssue(ctx, s.owner, s.repo, prNum, needsReviewLabel)
+	if err != nil && !isNotFound(err) {
+		return fmt.Errorf("remove needs-review label: %w", err)
+	}
+
+	if approved {
+		_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, prNum, []string{approvedLabel})
+		if err != nil {
+			return fmt.Errorf("add approved label: %w", err)
+		}
+		return nil
+	}
+
+	// Rejection: increment cycle counter.
+	newCycle := task.ReviewCycle + 1
+
+	// Remove old cycle label if present.
+	if task.ReviewCycle > 0 {
+		old := reviewCyclePrefix + strconv.Itoa(task.ReviewCycle)
+		_, _ = s.client.Issues.RemoveLabelForIssue(ctx, s.owner, s.repo, prNum, old) //nolint:errcheck
+	}
+
+	_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, prNum, []string{reviewCyclePrefix + strconv.Itoa(newCycle)})
+	if err != nil {
+		return fmt.Errorf("add review-cycle label: %w", err)
+	}
+
+	if newCycle >= 3 {
+		_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, prNum, []string{reviewAbandonedLabel})
+		if err != nil {
+			return fmt.Errorf("add review-abandoned label: %w", err)
+		}
+
+		commentBody := fmt.Sprintf("## Conductor: Review Abandoned\n\nAfter 3 QA review cycles, the implementation could not be brought into alignment with the spec.\n\n**Last QA feedback:** %s\n\nPlease review manually and either close this PR or push a revised implementation.",
+			body)
+		comment := &gh.IssueComment{Body: gh.Ptr(commentBody)}
+		_, _, err = s.client.Issues.CreateComment(ctx, s.owner, s.repo, prNum, comment)
+		if err != nil {
+			return fmt.Errorf("post abandonment comment: %w", err)
+		}
+		return nil
+	}
+
+	_, _, err = s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, prNum, []string{needsRevisionLabel})
+	if err != nil {
+		return fmt.Errorf("add needs-revision label: %w", err)
+	}
+	return nil
+}
+
+// prToReviewTask converts a GitHub PR to a review domain.Task.
+func prToReviewTask(pr *gh.PullRequest, repo string) *domain.Task {
+	labels := make([]string, 0, len(pr.Labels))
+	for _, l := range pr.Labels {
+		labels = append(labels, l.GetName())
+	}
+	specIssueNumber := parseIssueRef(pr)
+	return &domain.Task{
+		ID:              strconv.Itoa(pr.GetNumber()),
+		Title:           fmt.Sprintf("Review #%d: %s", pr.GetNumber(), pr.GetTitle()),
+		Labels:          labels,
+		Status:          domain.TaskStatusPending,
+		Source:          "github",
+		SourceURL:       pr.GetHTMLURL(),
+		Type:            domain.TaskTypeReview,
+		Branch:          pr.GetHead().GetRef(),
+		BaseBranch:      pr.GetBase().GetRef(),
+		SpecIssueNumber: specIssueNumber,
+	}
+}
+
+// prToReviseTask converts a GitHub PR to a revise domain.Task.
+func prToReviseTask(pr *gh.PullRequest, repo string) *domain.Task {
+	labels := make([]string, 0, len(pr.Labels))
+	for _, l := range pr.Labels {
+		labels = append(labels, l.GetName())
+	}
+	specIssueNumber := parseIssueRef(pr)
+	cycle := parseReviewCycle(pr)
+	return &domain.Task{
+		ID:              strconv.Itoa(pr.GetNumber()),
+		Title:           fmt.Sprintf("Revise #%d: %s", pr.GetNumber(), pr.GetTitle()),
+		Labels:          labels,
+		Status:          domain.TaskStatusPending,
+		Source:          "github",
+		SourceURL:       pr.GetHTMLURL(),
+		Type:            domain.TaskTypeRevise,
+		Branch:          pr.GetHead().GetRef(),
+		BaseBranch:      pr.GetBase().GetRef(),
+		SpecIssueNumber: specIssueNumber,
+		ReviewCycle:     cycle,
+	}
+}
+
+// parseIssueRef extracts the originating issue number from the conductor:issue-N label.
+func parseIssueRef(pr *gh.PullRequest) int {
+	for _, l := range pr.Labels {
+		name := l.GetName()
+		if strings.HasPrefix(name, issueRefPrefix) {
+			n, err := strconv.Atoi(strings.TrimPrefix(name, issueRefPrefix))
+			if err == nil {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+// parseReviewCycle extracts the current review cycle from conductor:review-cycle-N labels.
+func parseReviewCycle(pr *gh.PullRequest) int {
+	for _, l := range pr.Labels {
+		name := l.GetName()
+		if strings.HasPrefix(name, reviewCyclePrefix) {
+			n, err := strconv.Atoi(strings.TrimPrefix(name, reviewCyclePrefix))
+			if err == nil {
+				return n
+			}
+		}
+	}
+	return 0
 }
 
 // prHasLabel returns true if the PR has the named label.

--- a/internal/worksource/github_test.go
+++ b/internal/worksource/github_test.go
@@ -422,6 +422,390 @@ func TestRebaseAttempts_Parsing(t *testing.T) {
 	}
 }
 
+// --- MarkPRNeedsReview tests ---
+
+func TestMarkPRNeedsReview(t *testing.T) {
+	var addedLabels []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues/7/labels", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			var labels []string
+			json.NewDecoder(r.Body).Decode(&labels) //nolint:errcheck
+			addedLabels = append(addedLabels, labels...)
+			writeJSON(w, []any{})
+			return
+		}
+		writeJSON(w, []any{})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	err := s.MarkPRNeedsReview(context.Background(), 7, 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hasNeedsReview := false
+	hasIssueRef := false
+	for _, l := range addedLabels {
+		if l == needsReviewLabel {
+			hasNeedsReview = true
+		}
+		if l == issueRefPrefix+"42" {
+			hasIssueRef = true
+		}
+	}
+	if !hasNeedsReview {
+		t.Errorf("expected %q label, got %v", needsReviewLabel, addedLabels)
+	}
+	if !hasIssueRef {
+		t.Errorf("expected %q label, got %v", issueRefPrefix+"42", addedLabels)
+	}
+}
+
+// --- ListPRsNeedingReview tests ---
+
+func TestListPRsNeedingReview_ReturnsPRWithNeedsReview(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(7, "headSHA", "baseSHA", needsReviewLabel, issueRefPrefix+"42")})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListPRsNeedingReview(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	task := tasks[0]
+	if task.Type != domain.TaskTypeReview {
+		t.Errorf("expected type=review, got %q", task.Type)
+	}
+	if task.ID != "7" {
+		t.Errorf("expected ID=7, got %q", task.ID)
+	}
+	if task.SpecIssueNumber != 42 {
+		t.Errorf("expected SpecIssueNumber=42, got %d", task.SpecIssueNumber)
+	}
+}
+
+func TestListPRsNeedingReview_ExcludesReviewing(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(8, "headSHA", "baseSHA", needsReviewLabel, reviewingLabel)})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListPRsNeedingReview(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for PR already being reviewed, got %d", len(tasks))
+	}
+}
+
+func TestListPRsNeedingReview_ExcludesApproved(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(9, "headSHA", "baseSHA", needsReviewLabel, approvedLabel)})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListPRsNeedingReview(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for approved PR, got %d", len(tasks))
+	}
+}
+
+func TestListPRsNeedingReview_ExcludesAbandoned(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(10, "headSHA", "baseSHA", needsReviewLabel, reviewAbandonedLabel)})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListPRsNeedingReview(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for abandoned PR, got %d", len(tasks))
+	}
+}
+
+// --- ListPRsNeedingRevision tests ---
+
+func TestListPRsNeedingRevision_ReturnsPRWithNeedsRevision(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(11, "headSHA", "baseSHA", needsRevisionLabel, issueRefPrefix+"42", reviewCyclePrefix+"1")})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListPRsNeedingRevision(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	task := tasks[0]
+	if task.Type != domain.TaskTypeRevise {
+		t.Errorf("expected type=revise, got %q", task.Type)
+	}
+	if task.SpecIssueNumber != 42 {
+		t.Errorf("expected SpecIssueNumber=42, got %d", task.SpecIssueNumber)
+	}
+	if task.ReviewCycle != 1 {
+		t.Errorf("expected ReviewCycle=1, got %d", task.ReviewCycle)
+	}
+}
+
+func TestListPRsNeedingRevision_ExcludesRevising(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(12, "headSHA", "baseSHA", needsRevisionLabel, revisingLabel)})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListPRsNeedingRevision(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for PR already being revised, got %d", len(tasks))
+	}
+}
+
+func TestListPRsNeedingRevision_ExcludesAbandoned(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makePR(13, "headSHA", "baseSHA", needsRevisionLabel, reviewAbandonedLabel)})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	tasks, err := s.ListPRsNeedingRevision(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for abandoned PR, got %d", len(tasks))
+	}
+}
+
+// --- RecordReviewOutcome tests ---
+
+func TestRecordReviewOutcome_Approved(t *testing.T) {
+	var addedLabels []string
+	var deletedLabels []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues/7/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete:
+			// Extract label name from path
+			parts := strings.Split(r.URL.Path, "/")
+			if len(parts) > 0 {
+				deletedLabels = append(deletedLabels, parts[len(parts)-1])
+			}
+			writeJSON(w, []any{})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			var labels []string
+			json.NewDecoder(r.Body).Decode(&labels) //nolint:errcheck
+			addedLabels = append(addedLabels, labels...)
+			writeJSON(w, []any{})
+		default:
+			writeJSON(w, []any{})
+		}
+	})
+
+	s := newTestGitHubSource(t, mux)
+	task := &domain.Task{ID: "7", Type: domain.TaskTypeReview, ReviewCycle: 0}
+	err := s.RecordReviewOutcome(context.Background(), task, true, "Looks good!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hasApproved := false
+	for _, l := range addedLabels {
+		if l == approvedLabel {
+			hasApproved = true
+		}
+	}
+	if !hasApproved {
+		t.Errorf("expected %q label to be added, got %v", approvedLabel, addedLabels)
+	}
+}
+
+func TestRecordReviewOutcome_Rejected_FirstCycle(t *testing.T) {
+	var addedLabels []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues/7/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete:
+			writeJSON(w, []any{})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			var labels []string
+			json.NewDecoder(r.Body).Decode(&labels) //nolint:errcheck
+			addedLabels = append(addedLabels, labels...)
+			writeJSON(w, []any{})
+		default:
+			writeJSON(w, []any{})
+		}
+	})
+
+	s := newTestGitHubSource(t, mux)
+	task := &domain.Task{ID: "7", Type: domain.TaskTypeReview, ReviewCycle: 0}
+	err := s.RecordReviewOutcome(context.Background(), task, false, "Missing X feature")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hasCycle1 := false
+	hasNeedsRevision := false
+	for _, l := range addedLabels {
+		if l == reviewCyclePrefix+"1" {
+			hasCycle1 = true
+		}
+		if l == needsRevisionLabel {
+			hasNeedsRevision = true
+		}
+	}
+	if !hasCycle1 {
+		t.Errorf("expected %q label, got %v", reviewCyclePrefix+"1", addedLabels)
+	}
+	if !hasNeedsRevision {
+		t.Errorf("expected %q label, got %v", needsRevisionLabel, addedLabels)
+	}
+}
+
+func TestRecordReviewOutcome_ThirdCycle_Abandoned(t *testing.T) {
+	var addedLabels []string
+	var commentBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues/7/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete:
+			writeJSON(w, []any{})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			var labels []string
+			json.NewDecoder(r.Body).Decode(&labels) //nolint:errcheck
+			addedLabels = append(addedLabels, labels...)
+			writeJSON(w, []any{})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			var body struct {
+				Body string `json:"body"`
+			}
+			json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+			commentBody = body.Body
+			writeJSON(w, map[string]any{"id": 1})
+		default:
+			writeJSON(w, []any{})
+		}
+	})
+
+	s := newTestGitHubSource(t, mux)
+	task := &domain.Task{ID: "7", Type: domain.TaskTypeReview, ReviewCycle: 2}
+	err := s.RecordReviewOutcome(context.Background(), task, false, "still missing Y")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hasCycle3 := false
+	hasAbandoned := false
+	for _, l := range addedLabels {
+		if l == reviewCyclePrefix+"3" {
+			hasCycle3 = true
+		}
+		if l == reviewAbandonedLabel {
+			hasAbandoned = true
+		}
+	}
+	if !hasCycle3 {
+		t.Errorf("expected %q label, got %v", reviewCyclePrefix+"3", addedLabels)
+	}
+	if !hasAbandoned {
+		t.Errorf("expected %q label, got %v", reviewAbandonedLabel, addedLabels)
+	}
+	if !strings.Contains(commentBody, "Review Abandoned") {
+		t.Errorf("expected abandonment comment, got %q", commentBody)
+	}
+	if !strings.Contains(commentBody, "still missing Y") {
+		t.Errorf("expected feedback in comment, got %q", commentBody)
+	}
+}
+
+// --- Claim for review/revise tasks ---
+
+func TestClaim_ReviewTask(t *testing.T) {
+	var addedLabels []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues/7/labels", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			var labels []string
+			json.NewDecoder(r.Body).Decode(&labels) //nolint:errcheck
+			addedLabels = append(addedLabels, labels...)
+		}
+		writeJSON(w, []any{})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	task := &domain.Task{ID: "7", Type: domain.TaskTypeReview}
+	err := s.Claim(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hasReviewing := false
+	for _, l := range addedLabels {
+		if l == reviewingLabel {
+			hasReviewing = true
+		}
+	}
+	if !hasReviewing {
+		t.Errorf("expected %q label, got %v", reviewingLabel, addedLabels)
+	}
+}
+
+func TestClaim_ReviseTask(t *testing.T) {
+	var addedLabels []string
+	var deletedPaths []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues/7/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			var labels []string
+			json.NewDecoder(r.Body).Decode(&labels) //nolint:errcheck
+			addedLabels = append(addedLabels, labels...)
+			writeJSON(w, []any{})
+		case r.Method == http.MethodDelete:
+			deletedPaths = append(deletedPaths, r.URL.Path)
+			writeJSON(w, []any{})
+		default:
+			writeJSON(w, []any{})
+		}
+	})
+
+	s := newTestGitHubSource(t, mux)
+	task := &domain.Task{ID: "7", Type: domain.TaskTypeRevise}
+	err := s.Claim(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hasRevising := false
+	for _, l := range addedLabels {
+		if l == revisingLabel {
+			hasRevising = true
+		}
+	}
+	if !hasRevising {
+		t.Errorf("expected %q label, got %v", revisingLabel, addedLabels)
+	}
+	if len(deletedPaths) == 0 {
+		t.Error("expected needs-revision label to be removed")
+	}
+}
+
 func TestIssueToTask_FrontMatter(t *testing.T) {
 	body := "---\nconductor:\n  agent: claude\n---\nDo the thing"
 	num := 42

--- a/internal/worksource/linear.go
+++ b/internal/worksource/linear.go
@@ -291,3 +291,23 @@ func linearIssueToTask(issue linearIssue) *domain.Task {
 		UpdatedAt:   issue.UpdatedAt,
 	}
 }
+
+// ListPRsNeedingReview is not supported for Linear and always returns nil.
+func (s *LinearSource) ListPRsNeedingReview(_ context.Context) ([]*domain.Task, error) {
+	return nil, nil
+}
+
+// ListPRsNeedingRevision is not supported for Linear and always returns nil.
+func (s *LinearSource) ListPRsNeedingRevision(_ context.Context) ([]*domain.Task, error) {
+	return nil, nil
+}
+
+// RecordReviewOutcome is not supported for Linear and is a no-op.
+func (s *LinearSource) RecordReviewOutcome(_ context.Context, _ *domain.Task, _ bool, _ string) error {
+	return nil
+}
+
+// MarkPRNeedsReview is not supported for Linear and is a no-op.
+func (s *LinearSource) MarkPRNeedsReview(_ context.Context, _ int, _ int) error {
+	return nil
+}

--- a/internal/worksource/poller.go
+++ b/internal/worksource/poller.go
@@ -3,6 +3,7 @@ package worksource
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -80,7 +81,17 @@ func (p *TaskPoller) poll(ctx context.Context, out chan<- *domain.Task) {
 		slog.Error("list open PRs failed", "source", p.source.Name(), "error", err)
 	}
 
-	tasks := append(issueTasks, prTasks...)
+	reviewTasks, err := p.source.ListPRsNeedingReview(ctx)
+	if err != nil {
+		slog.Error("list PRs needing review failed", "source", p.source.Name(), "error", err)
+	}
+
+	reviseTasks, err := p.source.ListPRsNeedingRevision(ctx)
+	if err != nil {
+		slog.Error("list PRs needing revision failed", "source", p.source.Name(), "error", err)
+	}
+
+	tasks := slices.Concat(issueTasks, prTasks, reviewTasks, reviseTasks)
 
 	for _, task := range tasks {
 		if !p.tryAcquireSlot() {

--- a/internal/worksource/poller_test.go
+++ b/internal/worksource/poller_test.go
@@ -13,12 +13,14 @@ import (
 
 // mockSource is a controllable WorkSource for testing.
 type mockSource struct {
-	tasks     []*domain.Task
-	prTasks   []*domain.Task
-	claimErr  error
-	pollCount atomic.Int32
-	claimed   []string
-	mu        sync.Mutex
+	tasks        []*domain.Task
+	prTasks      []*domain.Task
+	reviewTasks  []*domain.Task
+	reviseTasks  []*domain.Task
+	claimErr     error
+	pollCount    atomic.Int32
+	claimed      []string
+	mu           sync.Mutex
 }
 
 func (m *mockSource) Name() string { return "mock" }
@@ -47,6 +49,22 @@ func (m *mockSource) ListOpenPRs(_ context.Context) ([]*domain.Task, error) {
 }
 
 func (m *mockSource) RecordRebaseOutcome(_ context.Context, _ *domain.Task, _ bool, _ string) error {
+	return nil
+}
+
+func (m *mockSource) ListPRsNeedingReview(_ context.Context) ([]*domain.Task, error) {
+	return m.reviewTasks, nil
+}
+
+func (m *mockSource) ListPRsNeedingRevision(_ context.Context) ([]*domain.Task, error) {
+	return m.reviseTasks, nil
+}
+
+func (m *mockSource) RecordReviewOutcome(_ context.Context, _ *domain.Task, _ bool, _ string) error {
+	return nil
+}
+
+func (m *mockSource) MarkPRNeedsReview(_ context.Context, _ int, _ int) error {
 	return nil
 }
 
@@ -148,6 +166,49 @@ func TestPoller_RebaseAndIssueTasks_BothFlow(t *testing.T) {
 	}
 	if !types[domain.TaskTypeRebase] {
 		t.Error("expected a rebase task to flow through the poller")
+	}
+}
+
+func TestPoller_AllFourSources_Flow(t *testing.T) {
+	issueTasks := makeTasks("issue-1")
+	prTask := &domain.Task{ID: "pr-1", Status: domain.TaskStatusPending, Type: domain.TaskTypeRebase}
+	reviewTask := &domain.Task{ID: "rev-1", Status: domain.TaskStatusPending, Type: domain.TaskTypeReview}
+	reviseTask := &domain.Task{ID: "rvs-1", Status: domain.TaskStatusPending, Type: domain.TaskTypeRevise}
+
+	src := &mockSource{
+		tasks:       issueTasks,
+		prTasks:     []*domain.Task{prTask},
+		reviewTasks: []*domain.Task{reviewTask},
+		reviseTasks: []*domain.Task{reviseTask},
+	}
+	p := NewPoller(src, PollerConfig{IntervalSeconds: 60, MaxConcurrentRuns: 4})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ch := p.Run(ctx)
+	var received []*domain.Task
+	for task := range ch {
+		received = append(received, task)
+		p.Done()
+		if len(received) == 4 {
+			cancel()
+		}
+	}
+
+	if len(received) != 4 {
+		t.Fatalf("expected 4 tasks (issue + rebase + review + revise), got %d", len(received))
+	}
+
+	types := map[domain.TaskType]int{}
+	for _, task := range received {
+		types[task.Type]++
+	}
+	if types[domain.TaskTypeReview] != 1 {
+		t.Errorf("expected 1 review task, got %d", types[domain.TaskTypeReview])
+	}
+	if types[domain.TaskTypeRevise] != 1 {
+		t.Errorf("expected 1 revise task, got %d", types[domain.TaskTypeRevise])
 	}
 }
 

--- a/internal/worksource/worksource.go
+++ b/internal/worksource/worksource.go
@@ -25,4 +25,18 @@ type WorkSource interface {
 	// attempt counter and, after 3 failures, marks the PR as abandoned and
 	// posts a comment explaining why.
 	RecordRebaseOutcome(ctx context.Context, task *domain.Task, succeeded bool, reason string) error
+	// ListPRsNeedingReview returns open PRs labelled conductor:needs-review that
+	// are not already being reviewed or terminal (approved, abandoned).
+	ListPRsNeedingReview(ctx context.Context) ([]*domain.Task, error)
+	// ListPRsNeedingRevision returns open PRs labelled conductor:needs-revision
+	// that are not already being revised or terminal (abandoned).
+	ListPRsNeedingRevision(ctx context.Context) ([]*domain.Task, error)
+	// RecordReviewOutcome updates labels after a QA review completes.
+	// On approval, adds conductor:approved and removes in-progress labels.
+	// On rejection, increments the cycle counter and, after 3 cycles, marks
+	// the PR as review-abandoned and posts an abandonment comment.
+	RecordReviewOutcome(ctx context.Context, task *domain.Task, approved bool, body string) error
+	// MarkPRNeedsReview adds conductor:needs-review to the PR and records the
+	// originating issue number as a conductor:issue-N label.
+	MarkPRNeedsReview(ctx context.Context, prNumber int, issueNumber int) error
 }


### PR DESCRIPTION
## Summary

Implements the full QA review loop as specified in #34:

- **New domain types**: `TaskTypeReview` and `TaskTypeRevise` with `ReviewCycle` and `SpecIssueNumber` fields
- **Label state machine**: `needs-review → reviewing → (approved | needs-revision + cycle-N | review-abandoned)`
- **4 new WorkSource methods**: `ListPRsNeedingReview`, `ListPRsNeedingRevision`, `RecordReviewOutcome`, `MarkPRNeedsReview`
- **GitHub implementation**: full label management including cycle tracking, abandonment after 3 cycles, and abandonment comments
- **Poller**: merges all 4 task sources (issues, rebases, reviews, revisions) via `slices.Concat`
- **Supervisor `executeReview`**: no worktree needed — QA agent runs from repo root, manages review outcome
- **Supervisor `executeRevise`**: reuses existing PR branch worktree, re-triggers review on success
- **Proof collector**: calls `MarkPRNeedsReview` after a PR URL is confirmed for issue tasks
- **Main**: routes review/revise task types in error and success paths
- **QA persona**: `.conductor/personas/qa-engineer/{SOUL,AGENTS}.md`

## Test plan

- [x] `go test ./...` passes
- [x] `go test -race ./...` passes
- [x] `TestListPRsNeedingReview_*` — detection and filtering
- [x] `TestListPRsNeedingRevision_*` — detection and filtering
- [x] `TestRecordReviewOutcome_Approved` — approval label management
- [x] `TestRecordReviewOutcome_Rejected_FirstCycle` — cycle label + needs-revision
- [x] `TestRecordReviewOutcome_ThirdCycle_Abandoned` — abandonment labels + comment
- [x] `TestClaim_ReviewTask`, `TestClaim_ReviseTask` — claiming mechanics
- [x] `TestPoller_AllFourSources_Flow` — all 4 task types through poller
- [x] `TestBuildReviewPrompt_Format`, `TestBuildRevisionPrompt_Format` — prompt content

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)