### PR TITLE
fix: replace dynamic conductor:issue-N label with PR body parsing

### DIFF
--- a/internal/worksource/github.go
+++ b/internal/worksource/github.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -28,7 +29,6 @@ const (
 	approvedLabel        = "conductor:approved"
 	reviewAbandonedLabel = "conductor:review-abandoned"
 	reviewCyclePrefix    = "conductor:review-cycle-"
-	issueRefPrefix       = "conductor:issue-"
 )
 
 // GitHubSource polls a GitHub repository for issues and claims them via labels.
@@ -282,11 +282,9 @@ func (s *GitHubSource) RecordRebaseOutcome(ctx context.Context, task *domain.Tas
 	return nil
 }
 
-// MarkPRNeedsReview adds conductor:needs-review to the PR and records the
-// originating issue number as a conductor:issue-N label.
+// MarkPRNeedsReview adds conductor:needs-review to the PR.
 func (s *GitHubSource) MarkPRNeedsReview(ctx context.Context, prNumber int, issueNumber int) error {
-	labels := []string{needsReviewLabel, issueRefPrefix + strconv.Itoa(issueNumber)}
-	_, _, err := s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, prNumber, labels)
+	_, _, err := s.client.Issues.AddLabelsToIssue(ctx, s.owner, s.repo, prNumber, []string{needsReviewLabel})
 	if err != nil {
 		return fmt.Errorf("mark PR #%d needs-review: %w", prNumber, err)
 	}
@@ -453,18 +451,16 @@ func prToReviseTask(pr *gh.PullRequest, repo string) *domain.Task {
 	}
 }
 
-// parseIssueRef extracts the originating issue number from the conductor:issue-N label.
+// parseIssueRef extracts the originating issue number from the PR body by
+// matching a "Closes #N" reference written by conductor at PR creation time.
 func parseIssueRef(pr *gh.PullRequest) int {
-	for _, l := range pr.Labels {
-		name := l.GetName()
-		if strings.HasPrefix(name, issueRefPrefix) {
-			n, err := strconv.Atoi(strings.TrimPrefix(name, issueRefPrefix))
-			if err == nil {
-				return n
-			}
-		}
+	re := regexp.MustCompile(`(?i)closes\s+#(\d+)`)
+	m := re.FindStringSubmatch(pr.GetBody())
+	if len(m) < 2 {
+		return 0
 	}
-	return 0
+	n, _ := strconv.Atoi(m[1])
+	return n
 }
 
 // parseReviewCycle extracts the current review cycle from conductor:review-cycle-N labels.

--- a/internal/worksource/github_test.go
+++ b/internal/worksource/github_test.go
@@ -74,6 +74,12 @@ func makePR(num int, head, base string, labels ...string) map[string]any {
 	}
 }
 
+func makePRWithBody(num int, head, base, body string, labels ...string) map[string]any {
+	m := makePR(num, head, base, labels...)
+	m["body"] = body
+	return m
+}
+
 func TestNewGitHubSource_InvalidRepo(t *testing.T) {
 	cases := []string{"", "noslash", "/nope", "nope/"}
 	for _, repo := range cases {
@@ -444,20 +450,18 @@ func TestMarkPRNeedsReview(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	hasNeedsReview := false
-	hasIssueRef := false
 	for _, l := range addedLabels {
 		if l == needsReviewLabel {
 			hasNeedsReview = true
-		}
-		if l == issueRefPrefix+"42" {
-			hasIssueRef = true
 		}
 	}
 	if !hasNeedsReview {
 		t.Errorf("expected %q label, got %v", needsReviewLabel, addedLabels)
 	}
-	if !hasIssueRef {
-		t.Errorf("expected %q label, got %v", issueRefPrefix+"42", addedLabels)
+	for _, l := range addedLabels {
+		if strings.HasPrefix(l, "conductor:issue-") {
+			t.Errorf("unexpected dynamic issue label added: %q", l)
+		}
 	}
 }
 
@@ -466,7 +470,7 @@ func TestMarkPRNeedsReview(t *testing.T) {
 func TestListPRsNeedingReview_ReturnsPRWithNeedsReview(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, []any{makePR(7, "headSHA", "baseSHA", needsReviewLabel, issueRefPrefix+"42")})
+		writeJSON(w, []any{makePRWithBody(7, "headSHA", "baseSHA", "Closes #42\n\nImplement the feature.", needsReviewLabel)})
 	})
 
 	s := newTestGitHubSource(t, mux)
@@ -542,7 +546,7 @@ func TestListPRsNeedingReview_ExcludesAbandoned(t *testing.T) {
 func TestListPRsNeedingRevision_ReturnsPRWithNeedsRevision(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/org/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, []any{makePR(11, "headSHA", "baseSHA", needsRevisionLabel, issueRefPrefix+"42", reviewCyclePrefix+"1")})
+		writeJSON(w, []any{makePRWithBody(11, "headSHA", "baseSHA", "Closes #42\n\nImplement the feature.", needsRevisionLabel, reviewCyclePrefix+"1")})
 	})
 
 	s := newTestGitHubSource(t, mux)
@@ -803,6 +807,27 @@ func TestClaim_ReviseTask(t *testing.T) {
 	}
 	if len(deletedPaths) == 0 {
 		t.Error("expected needs-revision label to be removed")
+	}
+}
+
+func TestParseIssueRef(t *testing.T) {
+	cases := []struct {
+		body     string
+		expected int
+	}{
+		{"Closes #42\n\nSome description", 42},
+		{"closes #7", 7},
+		{"CLOSES #100\n\nMore text", 100},
+		{"Closes  #42", 42},
+		{"No closing reference here", 0},
+		{"", 0},
+	}
+	for _, tc := range cases {
+		pr := &gh.PullRequest{Body: gh.Ptr(tc.body)}
+		got := parseIssueRef(pr)
+		if got != tc.expected {
+			t.Errorf("body=%q: expected %d, got %d", tc.body, tc.expected, got)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #37

## Summary
- `MarkPRNeedsReview` now only adds `conductor:needs-review`; the dynamic `conductor:issue-N` label (which caused GitHub 422 errors) is removed
- `parseIssueRef` extracts the originating issue number from the PR body via `(?i)closes\s+#(\d+)` regex instead of reading labels
- `issueRefPrefix` constant removed entirely

## Test plan
- [x] `go test ./...` passes
- [x] `TestMarkPRNeedsReview` verifies only `conductor:needs-review` is added and no `conductor:issue-*` label is added
- [x] `TestListPRsNeedingReview_ReturnsPRWithNeedsReview` uses PR body with `Closes #42` and verifies `SpecIssueNumber=42`
- [x] `TestListPRsNeedingRevision_ReturnsPRWithNeedsRevision` uses PR body with `Closes #42` and verifies `SpecIssueNumber=42`
- [x] `TestParseIssueRef` covers match, case-insensitivity, extra whitespace, and no-match cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)