### PR TITLE
fix: mkdir proof/ before writing summary.json

### DIFF
--- a/internal/proof/collector.go
+++ b/internal/proof/collector.go
@@ -239,6 +239,9 @@ func parseTestOutput(output string) (total, failures int) {
 }
 
 func writeSummary(path string, bundle *domain.ProofBundle) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create proof dir: %w", err)
+	}
 	data, err := json.MarshalIndent(bundle, "", "  ")
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Add `os.MkdirAll(filepath.Dir(path), 0755)` in `writeSummary` before calling `os.WriteFile`
- Makes proof collection self-sufficient — no longer depends on the supervisor having pre-created the `proof/` directory
- Wraps the mkdir error with context: `"create proof dir: %w"`

Closes #40