### PR TITLE
feat: allowed_authors allowlist for GitHub work source

### DIFF
--- a/cmd/conductor/main.go
+++ b/cmd/conductor/main.go
@@ -435,7 +435,7 @@ func buildWorkSource(cfg *config.Config) (worksource.WorkSource, error) {
 		if token == "" {
 			return nil, fmt.Errorf("GITHUB_TOKEN env var required for GitHub work source")
 		}
-		return worksource.NewGitHubSource(token, cfg.WorkSources.GitHub.Repo, cfg.WorkSources.GitHub.LabelFilter)
+		return worksource.NewGitHubSource(token, cfg.WorkSources.GitHub.Repo, cfg.WorkSources.GitHub.LabelFilter, cfg.WorkSources.GitHub.AllowedAuthors)
 	}
 	if cfg.WorkSources.Linear != nil {
 		token := os.Getenv("LINEAR_API_KEY")

--- a/conductor.toml.example
+++ b/conductor.toml.example
@@ -6,6 +6,7 @@ work_interval_seconds = 30
 [work_sources.github]
 repo = "your-org/your-repo"
 label_filter = ["conductor"]
+# allowed_authors = ["your-github-username"]  # optional: only claim issues from these users
 
 [providers.claude]
 enabled = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,8 +33,9 @@ type WorkSourcesConfig struct {
 }
 
 type GitHubSourceConfig struct {
-	Repo        string   `toml:"repo"`
-	LabelFilter []string `toml:"label_filter"`
+	Repo           string   `toml:"repo"`
+	LabelFilter    []string `toml:"label_filter"`
+	AllowedAuthors []string `toml:"allowed_authors"` // empty means allow all
 }
 
 type LinearSourceConfig struct {

--- a/internal/worksource/github.go
+++ b/internal/worksource/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -33,15 +34,16 @@ const (
 
 // GitHubSource polls a GitHub repository for issues and claims them via labels.
 type GitHubSource struct {
-	client      *gh.Client
-	owner       string
-	repo        string
-	labelFilter []string
+	client         *gh.Client
+	owner          string
+	repo           string
+	labelFilter    []string
+	allowedAuthors []string // empty = allow all
 }
 
 // NewGitHubSource creates a GitHubSource authenticated with the given token.
 // repo should be in "owner/repo" format.
-func NewGitHubSource(token, repo string, labelFilter []string) (*GitHubSource, error) {
+func NewGitHubSource(token, repo string, labelFilter []string, allowedAuthors []string) (*GitHubSource, error) {
 	parts := strings.SplitN(repo, "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return nil, fmt.Errorf("repo must be in owner/repo format, got %q", repo)
@@ -51,10 +53,11 @@ func NewGitHubSource(token, repo string, labelFilter []string) (*GitHubSource, e
 	tc := oauth2.NewClient(context.Background(), ts)
 
 	return &GitHubSource{
-		client:      gh.NewClient(tc),
-		owner:       parts[0],
-		repo:        parts[1],
-		labelFilter: labelFilter,
+		client:         gh.NewClient(tc),
+		owner:          parts[0],
+		repo:           parts[1],
+		labelFilter:    labelFilter,
+		allowedAuthors: allowedAuthors,
 	}, nil
 }
 
@@ -80,6 +83,9 @@ func (s *GitHubSource) Poll(ctx context.Context) ([]*domain.Task, error) {
 			continue
 		}
 		if hasLabel(issue, claimedLabel) || hasLabel(issue, runningLabel) {
+			continue
+		}
+		if !s.authorAllowed(issue) {
 			continue
 		}
 		tasks = append(tasks, issueToTask(issue, s.owner+"/"+s.repo))
@@ -149,6 +155,23 @@ func (s *GitHubSource) matchesFilter(issue *gh.Issue) bool {
 		}
 	}
 	return true
+}
+
+// authorAllowed returns true if the issue author is in the allowedAuthors list,
+// or if no allowlist is configured. Comparison is case-insensitive since GitHub
+// usernames are case-insensitive.
+func (s *GitHubSource) authorAllowed(issue *gh.Issue) bool {
+	if len(s.allowedAuthors) == 0 {
+		return true // no allowlist configured — allow all
+	}
+	author := issue.GetUser().GetLogin()
+	for _, allowed := range s.allowedAuthors {
+		if strings.EqualFold(allowed, author) {
+			return true
+		}
+	}
+	slog.Debug("issue skipped: author not in allowed_authors", "issue_id", issue.GetNumber(), "author", author)
+	return false
 }
 
 func hasLabel(issue *gh.Issue, name string) bool {

--- a/internal/worksource/github_test.go
+++ b/internal/worksource/github_test.go
@@ -83,7 +83,7 @@ func makePRWithBody(num int, head, base, body string, labels ...string) map[stri
 func TestNewGitHubSource_InvalidRepo(t *testing.T) {
 	cases := []string{"", "noslash", "/nope", "nope/"}
 	for _, repo := range cases {
-		_, err := NewGitHubSource("token", repo, nil)
+		_, err := NewGitHubSource("token", repo, nil, nil)
 		if err == nil {
 			t.Errorf("expected error for repo %q", repo)
 		}
@@ -91,7 +91,7 @@ func TestNewGitHubSource_InvalidRepo(t *testing.T) {
 }
 
 func TestNewGitHubSource_ValidRepo(t *testing.T) {
-	s, err := NewGitHubSource("token", "org/repo", []string{"conductor"})
+	s, err := NewGitHubSource("token", "org/repo", []string{"conductor"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -828,6 +828,128 @@ func TestParseIssueRef(t *testing.T) {
 		if got != tc.expected {
 			t.Errorf("body=%q: expected %d, got %d", tc.body, tc.expected, got)
 		}
+	}
+}
+
+// --- authorAllowed tests ---
+
+func makeIssueWithAuthor(num int, author string, labels ...string) *gh.Issue {
+	lbls := make([]*gh.Label, len(labels))
+	for i, l := range labels {
+		l := l
+		lbls[i] = &gh.Label{Name: &l}
+	}
+	return &gh.Issue{
+		Number: gh.Ptr(num),
+		Title:  gh.Ptr(fmt.Sprintf("Issue %d", num)),
+		User:   &gh.User{Login: gh.Ptr(author)},
+		Labels: lbls,
+	}
+}
+
+func TestAuthorAllowed_EmptyAllowlist(t *testing.T) {
+	s := &GitHubSource{allowedAuthors: nil}
+	issue := makeIssueWithAuthor(1, "anyone")
+	if !s.authorAllowed(issue) {
+		t.Error("expected authorAllowed to return true when allowedAuthors is empty")
+	}
+}
+
+func TestAuthorAllowed_AllowedAuthor(t *testing.T) {
+	s := &GitHubSource{allowedAuthors: []string{"alice", "bob"}}
+	issue := makeIssueWithAuthor(2, "alice")
+	if !s.authorAllowed(issue) {
+		t.Error("expected authorAllowed to return true for allowed author")
+	}
+}
+
+func TestAuthorAllowed_NotAllowedAuthor(t *testing.T) {
+	s := &GitHubSource{allowedAuthors: []string{"alice", "bob"}}
+	issue := makeIssueWithAuthor(3, "charlie")
+	if s.authorAllowed(issue) {
+		t.Error("expected authorAllowed to return false for non-allowed author")
+	}
+}
+
+func TestAuthorAllowed_CaseInsensitive(t *testing.T) {
+	s := &GitHubSource{allowedAuthors: []string{"alice"}}
+	issue := makeIssueWithAuthor(4, "Alice")
+	if !s.authorAllowed(issue) {
+		t.Error("expected authorAllowed to return true for case-insensitive match")
+	}
+}
+
+// Poll integration tests for author filtering.
+
+func makeIssueJSON(num int, author string, labels ...string) map[string]any {
+	lbls := make([]map[string]any, len(labels))
+	for i, l := range labels {
+		lbls[i] = map[string]any{"name": l}
+	}
+	return map[string]any{
+		"number":   num,
+		"title":    fmt.Sprintf("Issue %d", num),
+		"html_url": fmt.Sprintf("https://github.com/org/repo/issues/%d", num),
+		"body":     "",
+		"user":     map[string]any{"login": author},
+		"labels":   lbls,
+	}
+}
+
+func TestPoll_AllowedAuthorReturned(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makeIssueJSON(1, "alice", "conductor")})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	s.labelFilter = []string{"conductor"}
+	s.allowedAuthors = []string{"alice"}
+
+	tasks, err := s.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task for allowed author, got %d", len(tasks))
+	}
+}
+
+func TestPoll_NotAllowedAuthorSkipped(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makeIssueJSON(2, "bob", "conductor")})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	s.labelFilter = []string{"conductor"}
+	s.allowedAuthors = []string{"alice"}
+
+	tasks, err := s.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for non-allowed author, got %d", len(tasks))
+	}
+}
+
+func TestPoll_EmptyAllowedAuthors_AllowsAll(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makeIssueJSON(3, "anyone", "conductor")})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	s.labelFilter = []string{"conductor"}
+	s.allowedAuthors = nil
+
+	tasks, err := s.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task with empty allowedAuthors, got %d", len(tasks))
 	}
 }
 


### PR DESCRIPTION
Closes #42

## Summary

- Adds `AllowedAuthors []string` to `GitHubSourceConfig` (TOML tag: `allowed_authors`)
- Stores `allowedAuthors` on `GitHubSource` and passes it through `NewGitHubSource`
- Adds `authorAllowed` helper with case-insensitive matching (GitHub usernames are case-insensitive)
- Filters issues in `Poll` after label/claimed checks; emits a `slog.Debug` line when an issue is skipped
- Empty or absent `allowed_authors` preserves existing behaviour — all authors allowed
- 7 new tests covering: allowed author, non-allowed author, empty allowlist, and case-insensitive match
- Updates `conductor.toml.example` with a commented-out example

## Test plan

- [x] `go test ./...` passes
- [x] Issue from allowed author returned by `Poll`
- [x] Issue from non-allowed author skipped
- [x] Case-insensitive match (`alice` matches `Alice`)
- [x] Empty `allowed_authors` allows all authors