### PR TITLE
feat: allowed_authors allowlist for GitHub work source

### DIFF
--- a/cmd/conductor/main.go
+++ b/cmd/conductor/main.go
@@ -463,7 +463,7 @@ func buildWorkSource(cfg *config.Config) (worksource.WorkSource, error) {
 		if token == "" {
 			return nil, fmt.Errorf("GITHUB_TOKEN env var required for GitHub work source")
 		}
-		return worksource.NewGitHubSource(token, cfg.WorkSources.GitHub.Repo, cfg.WorkSources.GitHub.LabelFilter)
+		return worksource.NewGitHubSource(token, cfg.WorkSources.GitHub.Repo, cfg.WorkSources.GitHub.LabelFilter, cfg.WorkSources.GitHub.AllowedAuthors)
 	}
 	if cfg.WorkSources.Linear != nil {
 		token := os.Getenv("LINEAR_API_KEY")

--- a/conductor.toml.example
+++ b/conductor.toml.example
@@ -6,6 +6,7 @@ work_interval_seconds = 30
 [work_sources.github]
 repo = "your-org/your-repo"
 label_filter = ["conductor"]
+# allowed_authors = ["your-github-username"]  # optional: only claim issues from these users
 
 [providers.claude]
 enabled = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,8 +33,9 @@ type WorkSourcesConfig struct {
 }
 
 type GitHubSourceConfig struct {
-	Repo        string   `toml:"repo"`
-	LabelFilter []string `toml:"label_filter"`
+	Repo           string   `toml:"repo"`
+	LabelFilter    []string `toml:"label_filter"`
+	AllowedAuthors []string `toml:"allowed_authors"` // empty means allow all
 }
 
 type LinearSourceConfig struct {

--- a/internal/worksource/github.go
+++ b/internal/worksource/github.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	charmlog "github.com/charmbracelet/log"
 	gh "github.com/google/go-github/v68/github"
 	"golang.org/x/oauth2"
 
@@ -33,15 +34,16 @@ const (
 
 // GitHubSource polls a GitHub repository for issues and claims them via labels.
 type GitHubSource struct {
-	client      *gh.Client
-	owner       string
-	repo        string
-	labelFilter []string
+	client         *gh.Client
+	owner          string
+	repo           string
+	labelFilter    []string
+	allowedAuthors []string // empty = allow all
 }
 
 // NewGitHubSource creates a GitHubSource authenticated with the given token.
 // repo should be in "owner/repo" format.
-func NewGitHubSource(token, repo string, labelFilter []string) (*GitHubSource, error) {
+func NewGitHubSource(token, repo string, labelFilter []string, allowedAuthors []string) (*GitHubSource, error) {
 	parts := strings.SplitN(repo, "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return nil, fmt.Errorf("repo must be in owner/repo format, got %q", repo)
@@ -51,10 +53,11 @@ func NewGitHubSource(token, repo string, labelFilter []string) (*GitHubSource, e
 	tc := oauth2.NewClient(context.Background(), ts)
 
 	return &GitHubSource{
-		client:      gh.NewClient(tc),
-		owner:       parts[0],
-		repo:        parts[1],
-		labelFilter: labelFilter,
+		client:         gh.NewClient(tc),
+		owner:          parts[0],
+		repo:           parts[1],
+		labelFilter:    labelFilter,
+		allowedAuthors: allowedAuthors,
 	}, nil
 }
 
@@ -80,6 +83,10 @@ func (s *GitHubSource) Poll(ctx context.Context) ([]*domain.Task, error) {
 			continue
 		}
 		if hasLabel(issue, claimedLabel) || hasLabel(issue, runningLabel) {
+			continue
+		}
+		if !s.authorAllowed(issue) {
+			charmlog.Debug("issue skipped: author not in allowed_authors", "issue_id", issue.GetNumber(), "author", issue.GetUser().GetLogin())
 			continue
 		}
 		tasks = append(tasks, issueToTask(issue, s.owner+"/"+s.repo))
@@ -149,6 +156,21 @@ func (s *GitHubSource) matchesFilter(issue *gh.Issue) bool {
 		}
 	}
 	return true
+}
+
+// authorAllowed returns true if the issue author is in the allowed_authors list,
+// or if no allowlist is configured. Comparison is case-insensitive.
+func (s *GitHubSource) authorAllowed(issue *gh.Issue) bool {
+	if len(s.allowedAuthors) == 0 {
+		return true
+	}
+	author := issue.GetUser().GetLogin()
+	for _, allowed := range s.allowedAuthors {
+		if strings.EqualFold(allowed, author) {
+			return true
+		}
+	}
+	return false
 }
 
 func hasLabel(issue *gh.Issue, name string) bool {

--- a/internal/worksource/github_test.go
+++ b/internal/worksource/github_test.go
@@ -51,6 +51,23 @@ func writeJSON(w http.ResponseWriter, v any) {
 	json.NewEncoder(w).Encode(v) //nolint:errcheck
 }
 
+// --- helper issue builder ---
+
+func makeIssue(num int, author string, labels ...string) map[string]any {
+	lbls := make([]map[string]any, len(labels))
+	for i, l := range labels {
+		lbls[i] = map[string]any{"name": l}
+	}
+	return map[string]any{
+		"number":   num,
+		"title":    fmt.Sprintf("Issue %d", num),
+		"html_url": fmt.Sprintf("https://github.com/org/repo/issues/%d", num),
+		"body":     "",
+		"user":     map[string]any{"login": author},
+		"labels":   lbls,
+	}
+}
+
 // --- helper PR builder ---
 
 func makePR(num int, head, base string, labels ...string) map[string]any {
@@ -83,7 +100,7 @@ func makePRWithBody(num int, head, base, body string, labels ...string) map[stri
 func TestNewGitHubSource_InvalidRepo(t *testing.T) {
 	cases := []string{"", "noslash", "/nope", "nope/"}
 	for _, repo := range cases {
-		_, err := NewGitHubSource("token", repo, nil)
+		_, err := NewGitHubSource("token", repo, nil, nil)
 		if err == nil {
 			t.Errorf("expected error for repo %q", repo)
 		}
@@ -91,7 +108,7 @@ func TestNewGitHubSource_InvalidRepo(t *testing.T) {
 }
 
 func TestNewGitHubSource_ValidRepo(t *testing.T) {
-	s, err := NewGitHubSource("token", "org/repo", []string{"conductor"})
+	s, err := NewGitHubSource("token", "org/repo", []string{"conductor"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -828,6 +845,100 @@ func TestParseIssueRef(t *testing.T) {
 		if got != tc.expected {
 			t.Errorf("body=%q: expected %d, got %d", tc.body, tc.expected, got)
 		}
+	}
+}
+
+// --- authorAllowed / Poll author filter tests ---
+
+func TestAuthorAllowed_EmptyAllowlist(t *testing.T) {
+	s := &GitHubSource{}
+	issue := &gh.Issue{User: &gh.User{Login: gh.Ptr("anyone")}}
+	if !s.authorAllowed(issue) {
+		t.Error("expected authorAllowed=true when allowedAuthors is empty")
+	}
+}
+
+func TestAuthorAllowed_AllowedAuthor(t *testing.T) {
+	s := &GitHubSource{allowedAuthors: []string{"alice", "bob"}}
+	issue := &gh.Issue{User: &gh.User{Login: gh.Ptr("alice")}}
+	if !s.authorAllowed(issue) {
+		t.Error("expected authorAllowed=true for allowed author")
+	}
+}
+
+func TestAuthorAllowed_CaseInsensitive(t *testing.T) {
+	s := &GitHubSource{allowedAuthors: []string{"alice"}}
+	issue := &gh.Issue{User: &gh.User{Login: gh.Ptr("Alice")}}
+	if !s.authorAllowed(issue) {
+		t.Error("expected authorAllowed=true for case-insensitive match")
+	}
+}
+
+func TestAuthorAllowed_NotAllowed(t *testing.T) {
+	s := &GitHubSource{allowedAuthors: []string{"alice"}}
+	issue := &gh.Issue{User: &gh.User{Login: gh.Ptr("bob")}}
+	if s.authorAllowed(issue) {
+		t.Error("expected authorAllowed=false for author not in allowlist")
+	}
+}
+
+func TestPoll_AllowedAuthorReturned(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makeIssue(1, "alice", "conductor")})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	s.labelFilter = []string{"conductor"}
+	s.allowedAuthors = []string{"alice"}
+
+	tasks, err := s.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].ID != "1" {
+		t.Errorf("expected task ID=1, got %q", tasks[0].ID)
+	}
+}
+
+func TestPoll_NonAllowedAuthorSkipped(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makeIssue(2, "bob", "conductor")})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	s.labelFilter = []string{"conductor"}
+	s.allowedAuthors = []string{"alice"}
+
+	tasks, err := s.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for non-allowed author, got %d", len(tasks))
+	}
+}
+
+func TestPoll_EmptyAllowedAuthors_AllowsAll(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, []any{makeIssue(3, "anyone", "conductor")})
+	})
+
+	s := newTestGitHubSource(t, mux)
+	s.labelFilter = []string{"conductor"}
+	// allowedAuthors is nil — all authors allowed
+
+	tasks, err := s.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task with empty allowlist, got %d", len(tasks))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `AllowedAuthors []string` to `GitHubSourceConfig` (TOML: `allowed_authors`)
- Stores `allowedAuthors` on `GitHubSource` and passes it through `NewGitHubSource`
- Filters issues in `Poll` via new `authorAllowed` helper (case-insensitive, empty = allow all)
- Logs a debug line when an issue is skipped due to author not in allowlist
- Adds `conductor.toml.example` commented example

## Test plan
- [x] `go test ./...` passes
- [x] Issue from allowed author returned by Poll
- [x] Issue from non-allowed author skipped
- [x] Empty `allowed_authors` allows all authors
- [x] Case-insensitive match (Alice matches alice)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)