### PR TITLE
chore: add persona.toml identity fields to existing personas

### DIFF
--- a/.conductor/personas/debugging-specialist/persona.toml
+++ b/.conductor/personas/debugging-specialist/persona.toml
@@ -1,0 +1,3 @@
+name = "Jordan"
+email = "jordan@haha-systems.bot"
+github_token_env = "GITHUB_TOKEN_DEBUGGING_SPECIALIST"

--- a/.conductor/personas/lead-engineer/persona.toml
+++ b/.conductor/personas/lead-engineer/persona.toml
@@ -1,0 +1,3 @@
+name = "Alex"
+email = "alex@haha-systems.bot"
+github_token_env = "GITHUB_TOKEN_LEAD_ENGINEER"

--- a/.conductor/personas/qa-engineer/persona.toml
+++ b/.conductor/personas/qa-engineer/persona.toml
@@ -1,0 +1,3 @@
+name = "Casey"
+email = "casey@haha-systems.bot"
+github_token_env = "GITHUB_TOKEN_QA_ENGINEER"


### PR DESCRIPTION
Closes #50

Add `name`, `email`, and `github_token_env` fields to `persona.toml` files for all three current personas:

- `lead-engineer`: Alex / alex@haha-systems.bot / GITHUB_TOKEN_LEAD_ENGINEER
- `debugging-specialist`: Jordan / jordan@haha-systems.bot / GITHUB_TOKEN_DEBUGGING_SPECIALIST
- `qa-engineer`: Casey / casey@haha-systems.bot / GITHUB_TOKEN_QA_ENGINEER

No Go source changes. `go test ./...` passes.