### PR TITLE
feat: per-persona identity — config layer (DisplayName, Email, GitHubTokenEnv)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,14 +70,20 @@ type SandboxConfig struct {
 
 // PersonaConfig describes a named agent persona discovered from .conductor/personas/<name>/.
 type PersonaConfig struct {
-	Name     string // populated from directory name
-	Provider string `toml:"provider"` // from persona.toml, optional
-	Dir      string // absolute path to persona directory
+	Name           string // populated from directory name
+	Provider       string `toml:"provider"` // from persona.toml, optional
+	Dir            string // absolute path to persona directory
+	DisplayName    string // from persona.toml "name" — used as git author name
+	Email          string // from persona.toml "email" — used as git author email
+	GitHubTokenEnv string // env var name holding the persona's GitHub PAT
 }
 
 // personaTOML holds the optional persona.toml fields.
 type personaTOML struct {
-	Provider string `toml:"provider"`
+	Provider       string `toml:"provider"`
+	Name           string `toml:"name"`
+	Email          string `toml:"email"`
+	GitHubTokenEnv string `toml:"github_token_env"`
 }
 
 // Load reads and parses a conductor.toml file, applying defaults.
@@ -173,6 +179,9 @@ func discoverPersonas(repoRoot string) map[string]PersonaConfig {
 			var pt personaTOML
 			if _, err := toml.Decode(string(data), &pt); err == nil {
 				p.Provider = pt.Provider
+				p.DisplayName = pt.Name
+				p.Email = pt.Email
+				p.GitHubTokenEnv = pt.GitHubTokenEnv
 			}
 		}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -172,6 +172,59 @@ func TestDiscoverPersonas_WithPersonas(t *testing.T) {
 	}
 }
 
+func TestDiscoverPersonas_IdentityFields(t *testing.T) {
+	dir := t.TempDir()
+	personasDir := filepath.Join(dir, ".conductor", "personas")
+
+	// Persona with all three new fields.
+	withFieldsDir := filepath.Join(personasDir, "lead-engineer")
+	if err := os.MkdirAll(withFieldsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	toml := `provider = "claude"
+name = "Alex"
+email = "alex@haha-systems.bot"
+github_token_env = "GITHUB_TOKEN_LEAD_ENGINEER"
+`
+	os.WriteFile(filepath.Join(withFieldsDir, "persona.toml"), []byte(toml), 0644) //nolint:errcheck
+
+	// Persona with no persona.toml — fields should be empty strings.
+	noTomlDir := filepath.Join(personasDir, "no-toml")
+	if err := os.MkdirAll(noTomlDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	personas := discoverPersonas(dir)
+
+	le, ok := personas["lead-engineer"]
+	if !ok {
+		t.Fatal("expected lead-engineer persona")
+	}
+	if le.DisplayName != "Alex" {
+		t.Errorf("expected DisplayName=Alex, got %q", le.DisplayName)
+	}
+	if le.Email != "alex@haha-systems.bot" {
+		t.Errorf("expected Email=alex@haha-systems.bot, got %q", le.Email)
+	}
+	if le.GitHubTokenEnv != "GITHUB_TOKEN_LEAD_ENGINEER" {
+		t.Errorf("expected GitHubTokenEnv=GITHUB_TOKEN_LEAD_ENGINEER, got %q", le.GitHubTokenEnv)
+	}
+
+	nt, ok := personas["no-toml"]
+	if !ok {
+		t.Fatal("expected no-toml persona")
+	}
+	if nt.DisplayName != "" {
+		t.Errorf("expected empty DisplayName, got %q", nt.DisplayName)
+	}
+	if nt.Email != "" {
+		t.Errorf("expected empty Email, got %q", nt.Email)
+	}
+	if nt.GitHubTokenEnv != "" {
+		t.Errorf("expected empty GitHubTokenEnv, got %q", nt.GitHubTokenEnv)
+	}
+}
+
 func TestLoad_MissingFile(t *testing.T) {
 	_, err := Load(filepath.Join(t.TempDir(), "nonexistent.toml"))
 	if err == nil {


### PR DESCRIPTION
Closes #48

## Summary

- Extends `PersonaConfig` with `DisplayName`, `Email`, and `GitHubTokenEnv` fields
- Extends `personaTOML` to parse `name`, `email`, and `github_token_env` from `persona.toml`
- Populates the new fields in `discoverPersonas`
- Adds tests for both the happy path and the no-`persona.toml` zero-value case

Config layer only — no supervisor changes. Follow-up #49 will use these fields to inject the token and configure git authorship.

## Test plan
- [x] `go test ./...` passes
- [x] New fields populated correctly from `persona.toml`
- [x] Missing `persona.toml` → all new fields are empty strings, no error