### PR TITLE
feat: per-persona identity — supervisor token injection and git authorship

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -172,13 +172,11 @@ func TestDiscoverPersonas_WithPersonas(t *testing.T) {
 	}
 }
 
-func TestDiscoverPersonas_IdentityFields(t *testing.T) {
+func TestDiscoverPersonas_NewFields(t *testing.T) {
 	dir := t.TempDir()
 	personasDir := filepath.Join(dir, ".conductor", "personas")
-
-	// Persona with all three new fields.
-	withFieldsDir := filepath.Join(personasDir, "lead-engineer")
-	if err := os.MkdirAll(withFieldsDir, 0755); err != nil {
+	pDir := filepath.Join(personasDir, "lead-engineer")
+	if err := os.MkdirAll(pDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	toml := `provider = "claude"
@@ -186,42 +184,39 @@ name = "Alex"
 email = "alex@haha-systems.bot"
 github_token_env = "GITHUB_TOKEN_LEAD_ENGINEER"
 `
-	os.WriteFile(filepath.Join(withFieldsDir, "persona.toml"), []byte(toml), 0644) //nolint:errcheck
+	os.WriteFile(filepath.Join(pDir, "persona.toml"), []byte(toml), 0644) //nolint:errcheck
 
-	// Persona with no persona.toml — fields should be empty strings.
-	noTomlDir := filepath.Join(personasDir, "no-toml")
-	if err := os.MkdirAll(noTomlDir, 0755); err != nil {
+	personas := discoverPersonas(dir)
+	p, ok := personas["lead-engineer"]
+	if !ok {
+		t.Fatal("expected lead-engineer persona")
+	}
+	if p.DisplayName != "Alex" {
+		t.Errorf("expected DisplayName=Alex, got %q", p.DisplayName)
+	}
+	if p.Email != "alex@haha-systems.bot" {
+		t.Errorf("expected Email=alex@haha-systems.bot, got %q", p.Email)
+	}
+	if p.GitHubTokenEnv != "GITHUB_TOKEN_LEAD_ENGINEER" {
+		t.Errorf("expected GitHubTokenEnv=GITHUB_TOKEN_LEAD_ENGINEER, got %q", p.GitHubTokenEnv)
+	}
+}
+
+func TestDiscoverPersonas_NoToml_EmptyNewFields(t *testing.T) {
+	dir := t.TempDir()
+	personasDir := filepath.Join(dir, ".conductor", "personas")
+	pDir := filepath.Join(personasDir, "no-toml")
+	if err := os.MkdirAll(pDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	personas := discoverPersonas(dir)
-
-	le, ok := personas["lead-engineer"]
-	if !ok {
-		t.Fatal("expected lead-engineer persona")
-	}
-	if le.DisplayName != "Alex" {
-		t.Errorf("expected DisplayName=Alex, got %q", le.DisplayName)
-	}
-	if le.Email != "alex@haha-systems.bot" {
-		t.Errorf("expected Email=alex@haha-systems.bot, got %q", le.Email)
-	}
-	if le.GitHubTokenEnv != "GITHUB_TOKEN_LEAD_ENGINEER" {
-		t.Errorf("expected GitHubTokenEnv=GITHUB_TOKEN_LEAD_ENGINEER, got %q", le.GitHubTokenEnv)
-	}
-
-	nt, ok := personas["no-toml"]
+	p, ok := personas["no-toml"]
 	if !ok {
 		t.Fatal("expected no-toml persona")
 	}
-	if nt.DisplayName != "" {
-		t.Errorf("expected empty DisplayName, got %q", nt.DisplayName)
-	}
-	if nt.Email != "" {
-		t.Errorf("expected empty Email, got %q", nt.Email)
-	}
-	if nt.GitHubTokenEnv != "" {
-		t.Errorf("expected empty GitHubTokenEnv, got %q", nt.GitHubTokenEnv)
+	if p.DisplayName != "" || p.Email != "" || p.GitHubTokenEnv != "" {
+		t.Errorf("expected empty new fields for persona with no toml, got %+v", p)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -110,6 +110,11 @@ func (s *Supervisor) Execute(ctx context.Context, req RunRequest) *Result {
 		}
 	}
 
+	if err := configureGitAuthor(worktreePath, req.Persona); err != nil {
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("configure git author: %w", err))
+	}
+
 	// 3. Write task prompt to file.
 	taskFile := filepath.Join(worktreePath, ".conductor-task.md")
 	workflow := s.loadWorkflow(req.Persona)
@@ -139,8 +144,8 @@ func (s *Supervisor) Execute(ctx context.Context, req RunRequest) *Result {
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// 6. Build env: merge global + per-task.
-	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	// 6. Build env: merge global + per-task + persona.
+	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task), personaEnv(req.Persona))
 
 	rc := provider.RunContext{
 		RepoPath:       worktreePath,
@@ -292,15 +297,50 @@ func (lw *providerLogWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func mergeEnv(global, perTask map[string]string) map[string]string {
-	merged := make(map[string]string, len(global)+len(perTask))
-	for k, v := range global {
-		merged[k] = v
-	}
-	for k, v := range perTask {
-		merged[k] = v
+func mergeEnv(maps ...map[string]string) map[string]string {
+	merged := map[string]string{}
+	for _, m := range maps {
+		for k, v := range m {
+			merged[k] = v
+		}
 	}
 	return merged
+}
+
+func personaEnv(persona *config.PersonaConfig) map[string]string {
+	env := map[string]string{}
+	if persona == nil || persona.GitHubTokenEnv == "" {
+		return env
+	}
+	if token := os.Getenv(persona.GitHubTokenEnv); token != "" {
+		env["GITHUB_TOKEN"] = token
+	}
+	return env
+}
+
+func configureGitAuthor(worktreePath string, persona *config.PersonaConfig) error {
+	if persona == nil {
+		return nil
+	}
+	name := persona.DisplayName
+	if name == "" {
+		name = persona.Name
+	}
+	if name != "" {
+		cmd := exec.Command("git", "config", "user.name", name)
+		cmd.Dir = worktreePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git config user.name: %w: %s", err, out)
+		}
+	}
+	if persona.Email != "" {
+		cmd := exec.Command("git", "config", "user.email", persona.Email)
+		cmd.Dir = worktreePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git config user.email: %w: %s", err, out)
+		}
+	}
+	return nil
 }
 
 func taskEnv(task *domain.Task) map[string]string {
@@ -695,6 +735,12 @@ func (s *Supervisor) executeRevise(ctx context.Context, req RunRequest) *Result 
 		return s.fail(run, fmt.Errorf("create revise worktree: %w", err))
 	}
 
+	if err := configureGitAuthor(worktreePath, req.Persona); err != nil {
+		s.cleanup(run)
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("configure git author: %w", err))
+	}
+
 	// Build revision prompt.
 	prompt, err := s.buildRevisionPrompt(ctx, req.Task)
 	if err != nil {
@@ -731,7 +777,7 @@ func (s *Supervisor) executeRevise(ctx context.Context, req RunRequest) *Result 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task), personaEnv(req.Persona))
 	rc := provider.RunContext{
 		RepoPath:       worktreePath,
 		TaskFile:       taskFile,

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -353,6 +354,111 @@ func TestExtractRepoSlug(t *testing.T) {
 		if got != tc.expected {
 			t.Errorf("extractRepoSlug(%q) = %q, want %q", tc.url, got, tc.expected)
 		}
+	}
+}
+
+func TestPersonaEnv_WithToken(t *testing.T) {
+	t.Setenv("MY_PERSONA_TOKEN", "tok-abc123")
+	persona := &config.PersonaConfig{GitHubTokenEnv: "MY_PERSONA_TOKEN"}
+	env := personaEnv(persona)
+	if env["GITHUB_TOKEN"] != "tok-abc123" {
+		t.Errorf("expected GITHUB_TOKEN=tok-abc123, got %q", env["GITHUB_TOKEN"])
+	}
+}
+
+func TestPersonaEnv_NoGitHubTokenEnv(t *testing.T) {
+	persona := &config.PersonaConfig{Name: "lead-engineer"}
+	env := personaEnv(persona)
+	if len(env) != 0 {
+		t.Errorf("expected empty env when GitHubTokenEnv unset, got %v", env)
+	}
+}
+
+func TestPersonaEnv_NilPersona(t *testing.T) {
+	env := personaEnv(nil)
+	if len(env) != 0 {
+		t.Errorf("expected empty env for nil persona, got %v", env)
+	}
+}
+
+func TestPersonaEnv_EnvVarNotSet(t *testing.T) {
+	os.Unsetenv("UNSET_PERSONA_TOKEN") //nolint:errcheck
+	persona := &config.PersonaConfig{GitHubTokenEnv: "UNSET_PERSONA_TOKEN"}
+	env := personaEnv(persona)
+	if _, ok := env["GITHUB_TOKEN"]; ok {
+		t.Error("expected no GITHUB_TOKEN when env var is unset")
+	}
+}
+
+func TestConfigureGitAuthor_SetsNameAndEmail(t *testing.T) {
+	dir := t.TempDir()
+	// Initialize a real git repo so git config works.
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+
+	persona := &config.PersonaConfig{
+		Name:        "lead-engineer",
+		DisplayName: "Alex",
+		Email:       "alex@example.com",
+	}
+	if err := configureGitAuthor(dir, persona); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	nameOut, _ := exec.Command("git", "-C", dir, "config", "user.name").Output()
+	if strings.TrimSpace(string(nameOut)) != "Alex" {
+		t.Errorf("expected user.name=Alex, got %q", strings.TrimSpace(string(nameOut)))
+	}
+	emailOut, _ := exec.Command("git", "-C", dir, "config", "user.email").Output()
+	if strings.TrimSpace(string(emailOut)) != "alex@example.com" {
+		t.Errorf("expected user.email=alex@example.com, got %q", strings.TrimSpace(string(emailOut)))
+	}
+}
+
+func TestConfigureGitAuthor_FallsBackToName(t *testing.T) {
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+
+	persona := &config.PersonaConfig{
+		Name:        "lead-engineer",
+		DisplayName: "", // empty — should fall back to Name
+	}
+	if err := configureGitAuthor(dir, persona); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	nameOut, _ := exec.Command("git", "-C", dir, "config", "user.name").Output()
+	if strings.TrimSpace(string(nameOut)) != "lead-engineer" {
+		t.Errorf("expected user.name=lead-engineer, got %q", strings.TrimSpace(string(nameOut)))
+	}
+}
+
+func TestConfigureGitAuthor_NilPersona(t *testing.T) {
+	if err := configureGitAuthor(t.TempDir(), nil); err != nil {
+		t.Errorf("expected nil error for nil persona, got %v", err)
+	}
+}
+
+func TestMergeEnv_ThreeMaps(t *testing.T) {
+	a := map[string]string{"A": "1", "B": "base"}
+	b := map[string]string{"B": "mid", "C": "3"}
+	c := map[string]string{"B": "last", "D": "4"}
+
+	merged := mergeEnv(a, b, c)
+	if merged["A"] != "1" {
+		t.Errorf("expected A=1, got %s", merged["A"])
+	}
+	if merged["B"] != "last" {
+		t.Errorf("expected B=last (last map wins), got %s", merged["B"])
+	}
+	if merged["C"] != "3" {
+		t.Errorf("expected C=3, got %s", merged["C"])
+	}
+	if merged["D"] != "4" {
+		t.Errorf("expected D=4, got %s", merged["D"])
 	}
 }
 


### PR DESCRIPTION
Closes #49

Implements both #48 (config layer) and #49 (supervisor integration) in one branch since #48 had not yet merged.

## Changes

### Config layer (#48)
- `PersonaConfig` gains `DisplayName`, `Email`, `GitHubTokenEnv` fields
- `personaTOML` gains corresponding `name`, `email`, `github_token_env` TOML keys
- `discoverPersonas` populates the new fields after decoding `persona.toml`

### Supervisor (#49)
- `mergeEnv` made variadic — later maps win (persona token overrides conductor token)
- `personaEnv()` — reads the env var named by `GitHubTokenEnv` and injects it as `GITHUB_TOKEN`
- `configureGitAuthor()` — runs `git config user.name`/`user.email` in the worktree; falls back to `persona.Name` when `DisplayName` is empty
- `Execute` and `executeRevise` include persona env and call `configureGitAuthor` after worktree creation
- `executeRebase` and `executeReview` are unchanged (rebase replays existing commits, review makes no commits)

## Tests
- `personaEnv`: token injection, nil persona, unset env var
- `configureGitAuthor`: sets name+email, falls back to Name, nil persona no-ops
- `mergeEnv`: variadic three-map case
- Config: new TOML fields parsed correctly; missing `persona.toml` → empty fields

## Verification
- `go test ./...` ✓
- `go test -race ./...` ✓