### PR TITLE
chore: remove github_token_env from persona.toml files and conductor.toml.example

### DIFF
--- a/.conductor/personas/debugging-specialist/persona.toml
+++ b/.conductor/personas/debugging-specialist/persona.toml
@@ -1,3 +1,2 @@
 name = "Jordan"
 email = "jordan@haha-systems.bot"
-github_token_env = "GITHUB_TOKEN_DEBUGGING_SPECIALIST"

--- a/.conductor/personas/lead-engineer/persona.toml
+++ b/.conductor/personas/lead-engineer/persona.toml
@@ -1,3 +1,2 @@
 name = "Alex"
 email = "alex@haha-systems.bot"
-github_token_env = "GITHUB_TOKEN_LEAD_ENGINEER"

--- a/.conductor/personas/qa-engineer/persona.toml
+++ b/.conductor/personas/qa-engineer/persona.toml
@@ -1,3 +1,2 @@
 name = "Casey"
 email = "casey@haha-systems.bot"
-github_token_env = "GITHUB_TOKEN_QA_ENGINEER"

--- a/conductor.toml.example
+++ b/conductor.toml.example
@@ -8,20 +8,9 @@ repo = "your-org/your-repo"
 label_filter = ["conductor"]
 # allowed_authors = ["your-github-username"]  # optional: only claim issues from these users
 
-# Per-persona GitHub bot accounts (optional).
-#
-# Each persona can have its own GitHub account for opening PRs and posting
-# code reviews. Create a GitHub account per persona, generate a fine-grained
-# PAT with "Pull requests: read/write" and "Issues: read" scopes, and export
-# it as the named env var before running conductor.
-#
-# The env var name is set in each persona's persona.toml under github_token_env.
-# If not configured, the persona uses the conductor's own GITHUB_TOKEN.
-#
-# Example:
-#   export GITHUB_TOKEN_LEAD_ENGINEER="ghp_..."
-#   export GITHUB_TOKEN_QA_ENGINEER="ghp_..."
-#   export GITHUB_TOKEN_DEBUGGING_SPECIALIST="ghp_..."
+# Persona identity is expressed via git commit authorship (name/email in each
+# persona's persona.toml) and comment metadata. All personas share the
+# conductor's GITHUB_TOKEN for GitHub API operations.
 
 [providers.claude]
 enabled = true


### PR DESCRIPTION
Closes #56

Drops `github_token_env` from all persona.toml files and removes the per-persona bot token documentation from `conductor.toml.example`. Per-persona identity is now expressed solely via git commit authorship (name/email) and comment metadata, with all personas sharing the conductor's `GITHUB_TOKEN`.