### PR TITLE
fix: pipe task file via stdin and pass --prompt for Gemini non-interactive mode

### DIFF
--- a/conductor.toml.example
+++ b/conductor.toml.example
@@ -29,6 +29,12 @@ binary = "claude"
 extra_args = ["--model", "claude-sonnet-4-6", "--dangerously-skip-permissions"]
 cost_per_1k_tokens = 0.003
 
+# [providers.gemini]
+# enabled = false
+# binary = "gemini"
+# extra_args = ["--yolo"]
+# cost_per_1k_tokens = 0.0
+
 [routing]
 strategy = "round-robin"
 

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -1,6 +1,10 @@
 package provider
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"os"
+)
 
 // GeminiCLIAdapter invokes Google's `gemini` CLI.
 type GeminiCLIAdapter struct{ shell shellAdapter }
@@ -26,5 +30,11 @@ func (a *GeminiCLIAdapter) Name() string                                    { re
 func (a *GeminiCLIAdapter) Capabilities() []Capability                     { return a.shell.adapterCapabilities() }
 func (a *GeminiCLIAdapter) CostEstimate(n int) (float64, bool)             { return a.shell.adapterCostEstimate(n) }
 func (a *GeminiCLIAdapter) Run(ctx context.Context, rc RunContext) (RunHandle, error) {
-	return a.shell.adapterRun(ctx, rc)
+	f, err := os.Open(rc.TaskFile)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: open task file: %w", err)
+	}
+	// Pipe the task file as stdin. --prompt "" triggers non-interactive
+	// (headless) mode; Gemini appends the --prompt value to stdin content.
+	return a.shell.adapterRunWithStdin(ctx, rc, f, "--prompt", "")
 }


### PR DESCRIPTION
Closes #58

## Summary
- `GeminiCLIAdapter.Run` now opens the task file and pipes it as stdin via `adapterRunWithStdin`, with `--prompt ""` prepended to trigger headless mode
- Mirrors the existing Claude adapter pattern exactly
- Adds commented `[providers.gemini]` example to `conductor.toml.example` showing `--yolo` in `extra_args`

## Test plan
- [x] `go test ./...` passes
- [x] Gemini provider starts in non-interactive mode — task file content delivered as prompt
- [x] Process does not hang waiting for TTY input