### PR TITLE
fix: pass task file via run --file for non-interactive opencode mode

### DIFF
--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -22,5 +22,5 @@ func (a *OpenCodeAdapter) Name() string                                    { ret
 func (a *OpenCodeAdapter) Capabilities() []Capability                     { return a.shell.adapterCapabilities() }
 func (a *OpenCodeAdapter) CostEstimate(n int) (float64, bool)             { return a.shell.adapterCostEstimate(n) }
 func (a *OpenCodeAdapter) Run(ctx context.Context, rc RunContext) (RunHandle, error) {
-	return a.shell.adapterRun(ctx, rc)
+	return a.shell.adapterRun(ctx, rc, "run", "--file", rc.TaskFile)
 }


### PR DESCRIPTION
Closes #60

## Root Cause

`OpenCodeAdapter.Run` called `adapterRun(ctx, rc)` with no `prependArgs`, causing the `opencode` binary to receive no subcommand and launch its TUI instead of running headlessly. The task prompt was never delivered to the agent.

## Fix

Pass `"run", "--file", rc.TaskFile` as `prependArgs` to `adapterRun`, which invokes `opencode run --file <task_file>` — the correct headless interface.

## Testing

- Existing test suite passes (`go test ./...`)