### PR TITLE
feat: per-persona git authorship

### DIFF
--- a/.conductor/workpad.md
+++ b/.conductor/workpad.md
@@ -1,0 +1,29 @@
+## Plan
+- [ ] 1. Remove `GitHubTokenEnv` from config layer
+  - [ ] 1.1 Remove field from `PersonaConfig`
+  - [ ] 1.2 Remove field from `personaTOML` + TOML key
+  - [ ] 1.3 Remove assignment in `discoverPersonas`
+- [ ] 2. Add supervisor git authorship
+  - [ ] 2.1 Make `mergeEnv` variadic
+  - [ ] 2.2 Add `configureGitAuthor()` function
+  - [ ] 2.3 Call `configureGitAuthor` in `Execute` after worktree creation
+  - [ ] 2.4 Call `configureGitAuthor` in `executeRevise` after worktree creation
+- [ ] 3. Add tests
+  - [ ] 3.1 `configureGitAuthor`: sets name+email, falls back to Name, nil no-ops
+  - [ ] 3.2 `mergeEnv` variadic three-map case
+- [ ] 4. Run tests and validate
+
+## Acceptance Criteria
+- [ ] `GitHubTokenEnv` removed from `PersonaConfig`, `personaTOML`, `discoverPersonas`
+- [ ] `configureGitAuthor()` sets git user.name/user.email in worktree
+- [ ] Falls back to `persona.Name` when `DisplayName` is empty
+- [ ] Called in `Execute` and `executeRevise` after worktree creation
+- [ ] `mergeEnv` is variadic
+- [ ] All tests pass
+
+## Validation
+- [ ] `go test ./...`
+- [ ] `go test -race ./...`
+
+## Notes
+- 2026-03-20 00:29 — Starting rework from HEAD 05bf389. Closed PR #55. Scope: git authorship only, no token injection.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,20 +70,18 @@ type SandboxConfig struct {
 
 // PersonaConfig describes a named agent persona discovered from .conductor/personas/<name>/.
 type PersonaConfig struct {
-	Name           string // populated from directory name
-	Provider       string `toml:"provider"` // from persona.toml, optional
-	Dir            string // absolute path to persona directory
-	DisplayName    string // from persona.toml "name" — used as git author name
-	Email          string // from persona.toml "email" — used as git author email
-	GitHubTokenEnv string // env var name holding the persona's GitHub PAT
+	Name        string // populated from directory name
+	Provider    string `toml:"provider"` // from persona.toml, optional
+	Dir         string // absolute path to persona directory
+	DisplayName string // from persona.toml "name" — used as git author name
+	Email       string // from persona.toml "email" — used as git author email
 }
 
 // personaTOML holds the optional persona.toml fields.
 type personaTOML struct {
-	Provider       string `toml:"provider"`
-	Name           string `toml:"name"`
-	Email          string `toml:"email"`
-	GitHubTokenEnv string `toml:"github_token_env"`
+	Provider string `toml:"provider"`
+	Name     string `toml:"name"`
+	Email    string `toml:"email"`
 }
 
 // Load reads and parses a conductor.toml file, applying defaults.
@@ -181,7 +179,6 @@ func discoverPersonas(repoRoot string) map[string]PersonaConfig {
 				p.Provider = pt.Provider
 				p.DisplayName = pt.Name
 				p.Email = pt.Email
-				p.GitHubTokenEnv = pt.GitHubTokenEnv
 			}
 		}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -176,17 +176,16 @@ func TestDiscoverPersonas_IdentityFields(t *testing.T) {
 	dir := t.TempDir()
 	personasDir := filepath.Join(dir, ".conductor", "personas")
 
-	// Persona with all three new fields.
+	// Persona with display name and email.
 	withFieldsDir := filepath.Join(personasDir, "lead-engineer")
 	if err := os.MkdirAll(withFieldsDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	toml := `provider = "claude"
+	tomlContent := `provider = "claude"
 name = "Alex"
 email = "alex@haha-systems.bot"
-github_token_env = "GITHUB_TOKEN_LEAD_ENGINEER"
 `
-	os.WriteFile(filepath.Join(withFieldsDir, "persona.toml"), []byte(toml), 0644) //nolint:errcheck
+	os.WriteFile(filepath.Join(withFieldsDir, "persona.toml"), []byte(tomlContent), 0644) //nolint:errcheck
 
 	// Persona with no persona.toml — fields should be empty strings.
 	noTomlDir := filepath.Join(personasDir, "no-toml")
@@ -206,9 +205,6 @@ github_token_env = "GITHUB_TOKEN_LEAD_ENGINEER"
 	if le.Email != "alex@haha-systems.bot" {
 		t.Errorf("expected Email=alex@haha-systems.bot, got %q", le.Email)
 	}
-	if le.GitHubTokenEnv != "GITHUB_TOKEN_LEAD_ENGINEER" {
-		t.Errorf("expected GitHubTokenEnv=GITHUB_TOKEN_LEAD_ENGINEER, got %q", le.GitHubTokenEnv)
-	}
 
 	nt, ok := personas["no-toml"]
 	if !ok {
@@ -219,9 +215,6 @@ github_token_env = "GITHUB_TOKEN_LEAD_ENGINEER"
 	}
 	if nt.Email != "" {
 		t.Errorf("expected empty Email, got %q", nt.Email)
-	}
-	if nt.GitHubTokenEnv != "" {
-		t.Errorf("expected empty GitHubTokenEnv, got %q", nt.GitHubTokenEnv)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -108,6 +108,10 @@ func (s *Supervisor) Execute(ctx context.Context, req RunRequest) *Result {
 			s.cleanup(run)
 			return s.fail(run, fmt.Errorf("copy persona files: %w", err))
 		}
+		if err := configureGitAuthor(worktreePath, req.Persona); err != nil {
+			s.cleanup(run)
+			return s.fail(run, fmt.Errorf("configure git author: %w", err))
+		}
 	}
 
 	// 3. Write task prompt to file.
@@ -292,15 +296,35 @@ func (lw *providerLogWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func mergeEnv(global, perTask map[string]string) map[string]string {
-	merged := make(map[string]string, len(global)+len(perTask))
-	for k, v := range global {
-		merged[k] = v
-	}
-	for k, v := range perTask {
-		merged[k] = v
+func mergeEnv(maps ...map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for _, m := range maps {
+		for k, v := range m {
+			merged[k] = v
+		}
 	}
 	return merged
+}
+
+// configureGitAuthor sets git user.name and user.email in the worktree so
+// commits are attributed to the persona. Falls back to persona.Name when
+// DisplayName is empty. No-ops when persona is nil.
+func configureGitAuthor(worktreePath string, persona *config.PersonaConfig) error {
+	if persona == nil {
+		return nil
+	}
+	name := persona.DisplayName
+	if name == "" {
+		name = persona.Name
+	}
+	for _, kv := range [][2]string{{"user.name", name}, {"user.email", persona.Email}} {
+		cmd := exec.Command("git", "config", kv[0], kv[1])
+		cmd.Dir = worktreePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git config %s: %w: %s", kv[0], err, out)
+		}
+	}
+	return nil
 }
 
 func taskEnv(task *domain.Task) map[string]string {
@@ -693,6 +717,11 @@ func (s *Supervisor) executeRevise(ctx context.Context, req RunRequest) *Result 
 	if err := s.createRebaseBranchWorktree(worktreePath, req.Task.Branch); err != nil {
 		s.recordReviewOutcome(ctx, req, false, err.Error())
 		return s.fail(run, fmt.Errorf("create revise worktree: %w", err))
+	}
+	if err := configureGitAuthor(worktreePath, req.Persona); err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("configure git author: %w", err))
 	}
 
 	// Build revision prompt.

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -35,6 +36,19 @@ func TestMergeEnv_NilPerTask(t *testing.T) {
 	}
 }
 
+func TestMergeEnv_ThreeMaps(t *testing.T) {
+	a := map[string]string{"K": "a", "X": "1"}
+	b := map[string]string{"K": "b", "Y": "2"}
+	c := map[string]string{"K": "c", "Z": "3"}
+	merged := mergeEnv(a, b, c)
+	if merged["K"] != "c" {
+		t.Errorf("expected last map to win, got K=%s", merged["K"])
+	}
+	if merged["X"] != "1" || merged["Y"] != "2" || merged["Z"] != "3" {
+		t.Error("expected all unique keys to be present")
+	}
+}
+
 func TestTaskEnv_NilConfig(t *testing.T) {
 	task := &domain.Task{}
 	env := taskEnv(task)
@@ -52,6 +66,77 @@ func TestTaskEnv_WithConfig(t *testing.T) {
 	env := taskEnv(task)
 	if env["NODE_ENV"] != "test" {
 		t.Errorf("expected NODE_ENV=test, got %s", env["NODE_ENV"])
+	}
+}
+
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "init@test.com"},
+		{"config", "user.name", "Init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+}
+
+func TestConfigureGitAuthor_SetsNameAndEmail(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	persona := &config.PersonaConfig{
+		Name:        "lead-engineer",
+		DisplayName: "Lead Engineer",
+		Email:       "lead@example.com",
+	}
+	if err := configureGitAuthor(dir, persona); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for key, want := range map[string]string{
+		"user.name":  "Lead Engineer",
+		"user.email": "lead@example.com",
+	} {
+		out, err := exec.Command("git", "-C", dir, "config", key).Output()
+		if err != nil {
+			t.Fatalf("git config %s: %v", key, err)
+		}
+		if got := strings.TrimSpace(string(out)); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestConfigureGitAuthor_FallsBackToName(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	persona := &config.PersonaConfig{
+		Name:  "qa-engineer",
+		Email: "qa@example.com",
+		// DisplayName intentionally empty
+	}
+	if err := configureGitAuthor(dir, persona); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out, err := exec.Command("git", "-C", dir, "config", "user.name").Output()
+	if err != nil {
+		t.Fatalf("git config user.name: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "qa-engineer" {
+		t.Errorf("user.name = %q, want %q", got, "qa-engineer")
+	}
+}
+
+func TestConfigureGitAuthor_NilPersona(t *testing.T) {
+	// Should be a no-op with no error.
+	if err := configureGitAuthor(t.TempDir(), nil); err != nil {
+		t.Errorf("expected nil error for nil persona, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #49

Revised scope from PR #55: drop token injection, keep git authorship only.

All personas share a single GitHub App — identity is expressed through git commit authorship, not separate tokens.

## Changes

### Config
- Remove `GitHubTokenEnv` from `PersonaConfig` and `personaTOML` (and `github_token_env` TOML key)
- Keep `DisplayName` and `Email` on `PersonaConfig` + `name`/`email` TOML keys

### Supervisor
- `mergeEnv` made variadic — later maps win
- `configureGitAuthor()` — runs `git config user.name`/`user.email` in the worktree; falls back to `persona.Name` when `DisplayName` is empty; no-ops for nil persona
- `Execute` and `executeRevise` call `configureGitAuthor` after worktree creation
- `executeRebase` and `executeReview` are unchanged

## Tests
- `configureGitAuthor`: sets name+email, falls back to Name, nil no-ops
- `mergeEnv`: variadic three-map case
- Config: updated `TestDiscoverPersonas_IdentityFields` to drop `GitHubTokenEnv`

## Verification
- `go test ./...` ✓
- `go test -race ./...` ✓