### PR TITLE
feat: inject GitHub App installation token as GITHUB_TOKEN into agent env

### DIFF
--- a/cmd/ariadne/main.go
+++ b/cmd/ariadne/main.go
@@ -320,6 +320,7 @@ func executeRace(
 				Persona:      route.Persona,
 				Source:       source,
 				ReviewSource: source,
+				WorkSource:   source,
 			})
 			ch <- outcome{result: result, p: p}
 		}()
@@ -369,6 +370,7 @@ func executeRun(
 		Persona:      persona,
 		Source:       source,
 		ReviewSource: source,
+		WorkSource:   source,
 	})
 	if result.Err != nil {
 		log.Error("run failed", "run_id", run.ID, "error", result.Err)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -20,6 +20,13 @@ import (
 	"github.com/haha-systems/ariadne/internal/provider"
 )
 
+// TokenSource is satisfied by any WorkSource that can provide a GitHub API token
+// for injection into agent subprocess environments. It is used by the supervisor
+// without importing the worksource package directly.
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
 // RebaseRecorder is satisfied by any WorkSource that supports rebase outcome
 // recording. It is used by the supervisor without importing the worksource package.
 type RebaseRecorder interface {
@@ -46,6 +53,10 @@ type RunRequest struct {
 	Source RebaseRecorder
 	// ReviewSource is used by review/revise tasks to record outcomes. Nil is safe for other task types.
 	ReviewSource ReviewRecorder
+	// WorkSource optionally provides a GitHub token to inject as GITHUB_TOKEN into
+	// agent subprocess environments. If it implements TokenSource, the token is
+	// injected; otherwise no injection occurs. Nil is safe.
+	WorkSource any
 }
 
 // Result is returned by the supervisor after a run terminates.
@@ -144,7 +155,7 @@ func (s *Supervisor) Execute(ctx context.Context, req RunRequest) *Result {
 	defer cancel()
 
 	// 6. Build env: merge global + per-task.
-	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	env := buildEnv(ctx, req)
 
 	rc := provider.RunContext{
 		RepoPath:       worktreePath,
@@ -304,6 +315,19 @@ func mergeEnv(maps ...map[string]string) map[string]string {
 		}
 	}
 	return merged
+}
+
+// buildEnv builds the agent subprocess environment: merges global and per-task vars,
+// then injects GITHUB_TOKEN from WorkSource (if available) so gh CLI calls inside
+// the agent use the GitHub App installation token rather than the user's PAT.
+func buildEnv(ctx context.Context, req RunRequest) map[string]string {
+	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	if ts, ok := req.WorkSource.(TokenSource); ok {
+		if tok, err := ts.Token(ctx); err == nil && tok != "" {
+			env["GITHUB_TOKEN"] = tok
+		}
+	}
+	return env
 }
 
 // configureGitAuthor sets git user.name and user.email in the worktree so
@@ -533,7 +557,7 @@ func (s *Supervisor) executeRebase(ctx context.Context, req RunRequest) *Result 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	env := buildEnv(ctx, req)
 	rc := provider.RunContext{
 		RepoPath:       worktreePath,
 		TaskFile:       taskFile,
@@ -639,7 +663,7 @@ func (s *Supervisor) executeReview(ctx context.Context, req RunRequest) *Result 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	env := buildEnv(ctx, req)
 	rc := provider.RunContext{
 		RepoPath:       s.cfg.RepoRoot,
 		TaskFile:       taskFile,
@@ -760,7 +784,7 @@ func (s *Supervisor) executeRevise(ctx context.Context, req RunRequest) *Result 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+	env := buildEnv(ctx, req)
 	rc := provider.RunContext{
 		RepoPath:       worktreePath,
 		TaskFile:       taskFile,

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,11 @@ import (
 	"github.com/haha-systems/ariadne/internal/config"
 	"github.com/haha-systems/ariadne/internal/domain"
 )
+
+// mockTokenSource implements TokenSource for testing.
+type mockTokenSource struct{ token string }
+
+func (m *mockTokenSource) Token(_ context.Context) (string, error) { return m.token, nil }
 
 func TestMergeEnv(t *testing.T) {
 	global := map[string]string{"A": "1", "B": "2"}
@@ -66,6 +72,49 @@ func TestTaskEnv_WithConfig(t *testing.T) {
 	env := taskEnv(task)
 	if env["NODE_ENV"] != "test" {
 		t.Errorf("expected NODE_ENV=test, got %s", env["NODE_ENV"])
+	}
+}
+
+func TestBuildEnv_InjectsGitHubToken(t *testing.T) {
+	task := &domain.Task{}
+	req := RunRequest{
+		Task:       task,
+		GlobalEnv:  map[string]string{"X": "1"},
+		WorkSource: &mockTokenSource{token: "ghs_test_token"},
+	}
+	env := buildEnv(context.Background(), req)
+	if env["GITHUB_TOKEN"] != "ghs_test_token" {
+		t.Errorf("expected GITHUB_TOKEN=ghs_test_token, got %q", env["GITHUB_TOKEN"])
+	}
+	if env["X"] != "1" {
+		t.Errorf("expected X=1, got %q", env["X"])
+	}
+}
+
+func TestBuildEnv_NoTokenSource(t *testing.T) {
+	task := &domain.Task{}
+	req := RunRequest{
+		Task:       task,
+		GlobalEnv:  map[string]string{"X": "1"},
+		WorkSource: nil,
+	}
+	env := buildEnv(context.Background(), req)
+	if _, ok := env["GITHUB_TOKEN"]; ok {
+		t.Errorf("expected no GITHUB_TOKEN when WorkSource is nil, got %q", env["GITHUB_TOKEN"])
+	}
+}
+
+func TestBuildEnv_NonTokenSourceWorkSource(t *testing.T) {
+	// A WorkSource that does not implement TokenSource should not inject GITHUB_TOKEN.
+	type noopSource struct{}
+	task := &domain.Task{}
+	req := RunRequest{
+		Task:       task,
+		WorkSource: &noopSource{},
+	}
+	env := buildEnv(context.Background(), req)
+	if _, ok := env["GITHUB_TOKEN"]; ok {
+		t.Errorf("expected no GITHUB_TOKEN when WorkSource lacks Token(), got %q", env["GITHUB_TOKEN"])
 	}
 }
 

--- a/internal/worksource/github.go
+++ b/internal/worksource/github.go
@@ -36,11 +36,13 @@ const (
 
 // GitHubSource polls a GitHub repository for issues and claims them via labels.
 type GitHubSource struct {
-	client         *gh.Client
-	owner          string
-	repo           string
-	labelFilter    []string
-	allowedAuthors []string // empty = allow all
+	client           *gh.Client
+	owner            string
+	repo             string
+	labelFilter      []string
+	allowedAuthors   []string // empty = allow all
+	installTransport *ghinstallation.Transport // non-nil when using GitHub App auth
+	staticToken      string                    // used when installTransport is nil
 }
 
 // NewGitHubSource creates a GitHubSource authenticated with the given token.
@@ -53,6 +55,7 @@ func NewGitHubSource(token, repo string, labelFilter []string, allowedAuthors []
 	owner, repoName := parts[0], parts[1]
 
 	var tc *http.Client
+	var installTransport *ghinstallation.Transport
 	appIDStr, keyPath := os.Getenv("GH_APP_APP_ID"), os.Getenv("GH_APP_PRIVATE_KEY_PATH")
 	if appIDStr != "" && keyPath != "" {
 		id, err := strconv.ParseInt(appIDStr, 10, 64)
@@ -68,23 +71,35 @@ func NewGitHubSource(token, repo string, labelFilter []string, allowedAuthors []
 		if err != nil {
 			return nil, fmt.Errorf("find installation: %w", err)
 		}
-		itr := ghinstallation.NewFromAppsTransport(atr, inst.GetID())
-		tc = &http.Client{Transport: itr}
+		installTransport = ghinstallation.NewFromAppsTransport(atr, inst.GetID())
+		tc = &http.Client{Transport: installTransport}
 	} else {
 		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 		tc = oauth2.NewClient(context.Background(), ts)
 	}
 
 	return &GitHubSource{
-		client:         gh.NewClient(tc),
-		owner:          owner,
-		repo:           repoName,
-		labelFilter:    labelFilter,
-		allowedAuthors: allowedAuthors,
+		client:           gh.NewClient(tc),
+		owner:            owner,
+		repo:             repoName,
+		labelFilter:      labelFilter,
+		allowedAuthors:   allowedAuthors,
+		installTransport: installTransport,
+		staticToken:      token,
 	}, nil
 }
 
 func (s *GitHubSource) Name() string { return "github" }
+
+// Token returns a valid GitHub API token for the current authentication method.
+// When using GitHub App auth, this fetches a fresh installation token (auto-renewed
+// by the transport). When using a PAT, it returns the static token.
+func (s *GitHubSource) Token(ctx context.Context) (string, error) {
+	if s.installTransport != nil {
+		return s.installTransport.Token(ctx)
+	}
+	return s.staticToken, nil
+}
 
 // Poll fetches open issues that have all required labels but have NOT been claimed yet.
 func (s *GitHubSource) Poll(ctx context.Context) ([]*domain.Task, error) {


### PR DESCRIPTION
## Summary

- When using GitHub App auth, agent subprocesses now receive a fresh installation token as `GITHUB_TOKEN` so `gh` CLI calls are authenticated as AriadneBot rather than inheriting the user's PAT
- Adds `Token(ctx)` method to `GitHubSource` backed by the `ghinstallation.Transport` (App auth) or the static PAT
- Adds `TokenSource` interface + `WorkSource any` field on `RunRequest`; supervisor type-asserts and injects `GITHUB_TOKEN` via new `buildEnv` helper
- Falls back gracefully when `WorkSource` is nil or doesn't implement `TokenSource` (e.g. LinearSource)

## Test plan

- [x] `TestBuildEnv_InjectsGitHubToken` — token is set when WorkSource implements TokenSource
- [x] `TestBuildEnv_NoTokenSource` — no GITHUB_TOKEN when WorkSource is nil
- [x] `TestBuildEnv_NonTokenSourceWorkSource` — no GITHUB_TOKEN when WorkSource lacks Token()
- [x] `go test ./...` passes

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)