### PR TITLE
feat: use GitHub MCP server for agent GitHub operations

### DIFF
--- a/.ariadne/WORKFLOW.md
+++ b/.ariadne/WORKFLOW.md
@@ -9,7 +9,23 @@ resolved in-session.
 
 - **Worktree**: your isolated repo copy — work only here.
 - **Task**: see the header above for title, source URL, labels, and description.
-- **Tools**: `gh` CLI, `git`, and any repo-specific tooling.
+- **Tools**: GitHub MCP server (for all GitHub operations), `git`, and any repo-specific tooling.
+
+## GitHub Operations
+
+Use the GitHub MCP server tools for all GitHub interactions — do **not** use the `gh` CLI.
+
+| Operation | MCP tool |
+|-----------|----------|
+| Read an issue | `get_issue` |
+| List issues | `list_issues` |
+| Post a comment | `create_issue_comment` |
+| Add labels | `add_labels_to_issue` |
+| Create a PR | `create_pull_request` |
+| Read a PR | `get_pull_request` |
+| Merge a PR | `merge_pull_request` |
+| Check PR CI status | `get_pull_request_checks` |
+| List PR comments | `get_pull_request_comments` |
 
 ## Progress tracking
 
@@ -44,14 +60,14 @@ Create this file at `.ariadne/workpad.md` at the start of every run:
 
 ## Step 0 — Orient
 
-1. Read the issue: `gh issue view <number> --repo <owner/repo> --comments`
+1. Read the issue using the `get_issue` MCP tool.
 2. Check current state and route:
    - **Backlog** → stop; wait for a human to move it.
    - **Todo / In Progress** → continue below.
    - **Human Review** → poll for review feedback; if changes requested, move to Rework.
-   - **Merging** → rebase on main, confirm CI green, merge via `gh pr merge --rebase --delete-branch`.
+   - **Merging** → rebase on main, confirm CI green, merge via `merge_pull_request` MCP tool.
    - **Done / Cancelled** → nothing to do; stop.
-3. Move issue to **In Progress** if it isn't already.
+3. Move issue to **In Progress** if it isn't already (use `add_labels_to_issue`).
 4. Create `.ariadne/workpad.md` (fresh run) or open and reconcile it (retry).
 5. Sync: `git fetch origin && git rebase origin/main` — record resulting HEAD SHA in Notes.
 
@@ -77,15 +93,14 @@ Create this file at `.ariadne/workpad.md` at the start of every run:
 ## Step 4 — PR and handoff
 
 1. Push branch and open a PR targeting `main`. Include `Closes #<issue-number>`
-   in the PR body (the issue number is in the task header above):
-   `gh pr create --title "..." --body "Closes #N\n\n..." --repo <owner/repo>`
+   in the PR body. Use the `create_pull_request` MCP tool.
 2. Capture the PR URL and write it to `.ariadne/metadata.json`:
    ```json
    {"pr_url": "https://github.com/org/repo/pull/N"}
    ```
 3. Attach the PR to the issue.
-4. Poll PR checks — loop until green or until a failure requires a code fix.
-5. Run a PR feedback sweep (inline comments + review summaries); address or
+4. Poll PR checks using `get_pull_request_checks` — loop until green or until a failure requires a code fix.
+5. Read inline comments and review summaries via `get_pull_request_comments`; address or
    explicitly respond to every actionable comment.
 6. Move issue to **Human Review**.
 
@@ -93,7 +108,7 @@ Create this file at `.ariadne/workpad.md` at the start of every run:
 
 Treat Rework as a full reset, not a patch:
 
-1. Read the full issue and all comments to understand what to do differently.
+1. Read the full issue and all comments using `get_issue` and `get_pull_request_comments`.
 2. Close the existing PR.
 3. Delete `.ariadne/workpad.md`.
 4. Create a fresh branch from `origin/main`.

--- a/cmd/ariadne/main.go
+++ b/cmd/ariadne/main.go
@@ -310,6 +310,7 @@ func executeRace(
 
 	ch := make(chan outcome, len(route.Providers))
 
+	ts := tokenSource(source)
 	for _, p := range route.Providers {
 		go func() {
 			run := &domain.Run{ID: newRunID(), TaskID: task.ID, Provider: p.Name()}
@@ -320,6 +321,7 @@ func executeRace(
 				Persona:      route.Persona,
 				Source:       source,
 				ReviewSource: source,
+				TokenSource:  ts,
 			})
 			ch <- outcome{result: result, p: p}
 		}()
@@ -369,6 +371,7 @@ func executeRun(
 		Persona:      persona,
 		Source:       source,
 		ReviewSource: source,
+		TokenSource:  tokenSource(source),
 	})
 	if result.Err != nil {
 		log.Error("run failed", "run_id", run.ID, "error", result.Err)
@@ -473,6 +476,15 @@ func buildWorkSource(cfg *config.Config) (worksource.WorkSource, error) {
 		return worksource.NewLinearSource(token, cfg.WorkSources.Linear.TeamID, cfg.WorkSources.Linear.StateFilter)
 	}
 	return nil, fmt.Errorf("no work source configured — add [work_sources.github] or [work_sources.linear] to ariadne.toml")
+}
+
+// tokenSource extracts a supervisor.TokenSource from a WorkSource if the
+// underlying implementation supports it. Returns nil for non-GitHub sources.
+func tokenSource(ws worksource.WorkSource) supervisor.TokenSource {
+	if ts, ok := ws.(supervisor.TokenSource); ok {
+		return ts
+	}
+	return nil
 }
 
 func repoRoot() string {

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -35,5 +35,9 @@ func (a *ClaudeCodeAdapter) Run(ctx context.Context, rc RunContext) (RunHandle, 
 	if err != nil {
 		return nil, fmt.Errorf("claude: open task file: %w", err)
 	}
-	return a.shell.adapterRunWithStdin(ctx, rc, f, "--print")
+	args := []string{"--print"}
+	if rc.MCPConfigPath != "" {
+		args = append(args, "--mcp-config", rc.MCPConfigPath)
+	}
+	return a.shell.adapterRunWithStdin(ctx, rc, f, args...)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -28,6 +28,9 @@ type RunContext struct {
 	LogWriter io.Writer
 	// TimeoutSeconds is the wall-clock timeout for the run.
 	TimeoutSeconds int
+	// MCPConfigPath is the path to a temporary MCP config JSON file pointing to
+	// the github-mcp-server process. Empty string means no MCP server was started.
+	MCPConfigPath string
 }
 
 // RunHandle represents a running provider subprocess.

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -20,6 +20,12 @@ import (
 	"github.com/haha-systems/ariadne/internal/provider"
 )
 
+// TokenSource is satisfied by any WorkSource that can supply a GitHub API token.
+// The supervisor uses it to authenticate the GitHub MCP server process.
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
 // RebaseRecorder is satisfied by any WorkSource that supports rebase outcome
 // recording. It is used by the supervisor without importing the worksource package.
 type RebaseRecorder interface {
@@ -46,6 +52,8 @@ type RunRequest struct {
 	Source RebaseRecorder
 	// ReviewSource is used by review/revise tasks to record outcomes. Nil is safe for other task types.
 	ReviewSource ReviewRecorder
+	// TokenSource provides a GitHub API token for the MCP server. Nil disables MCP server injection.
+	TokenSource TokenSource
 }
 
 // Result is returned by the supervisor after a run terminates.
@@ -146,12 +154,20 @@ func (s *Supervisor) Execute(ctx context.Context, req RunRequest) *Result {
 	// 6. Build env: merge global + per-task.
 	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
 
+	mcpConfigPath, mcpCleanup, err := writeMCPConfig(ctx, req.TokenSource)
+	if err != nil {
+		s.cleanup(run)
+		return s.fail(run, fmt.Errorf("write MCP config: %w", err))
+	}
+	defer mcpCleanup()
+
 	rc := provider.RunContext{
 		RepoPath:       worktreePath,
 		TaskFile:       taskFile,
 		Env:            env,
 		LogWriter:      logWriter,
 		TimeoutSeconds: int(timeout.Seconds()),
+		MCPConfigPath:  mcpConfigPath,
 	}
 
 	// 7. Launch provider.
@@ -534,12 +550,22 @@ func (s *Supervisor) executeRebase(ctx context.Context, req RunRequest) *Result 
 	defer cancel()
 
 	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+
+	mcpConfigPath, mcpCleanup, err := writeMCPConfig(ctx, req.TokenSource)
+	if err != nil {
+		s.cleanup(run)
+		s.recordRebaseOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("write MCP config: %w", err))
+	}
+	defer mcpCleanup()
+
 	rc := provider.RunContext{
 		RepoPath:       worktreePath,
 		TaskFile:       taskFile,
 		Env:            env,
 		LogWriter:      logWriter,
 		TimeoutSeconds: int(timeout.Seconds()),
+		MCPConfigPath:  mcpConfigPath,
 	}
 
 	logEvent(logFile, "run_started", map[string]any{
@@ -640,12 +666,21 @@ func (s *Supervisor) executeReview(ctx context.Context, req RunRequest) *Result 
 	defer cancel()
 
 	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+
+	mcpConfigPath, mcpCleanup, err := writeMCPConfig(ctx, req.TokenSource)
+	if err != nil {
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("write MCP config: %w", err))
+	}
+	defer mcpCleanup()
+
 	rc := provider.RunContext{
 		RepoPath:       s.cfg.RepoRoot,
 		TaskFile:       taskFile,
 		Env:            env,
 		LogWriter:      logWriter,
 		TimeoutSeconds: int(timeout.Seconds()),
+		MCPConfigPath:  mcpConfigPath,
 	}
 
 	logEvent(logFile, "run_started", map[string]any{
@@ -761,12 +796,22 @@ func (s *Supervisor) executeRevise(ctx context.Context, req RunRequest) *Result 
 	defer cancel()
 
 	env := mergeEnv(req.GlobalEnv, taskEnv(req.Task))
+
+	mcpConfigPath, mcpCleanup, err := writeMCPConfig(ctx, req.TokenSource)
+	if err != nil {
+		s.cleanup(run)
+		s.recordReviewOutcome(ctx, req, false, err.Error())
+		return s.fail(run, fmt.Errorf("write MCP config: %w", err))
+	}
+	defer mcpCleanup()
+
 	rc := provider.RunContext{
 		RepoPath:       worktreePath,
 		TaskFile:       taskFile,
 		Env:            env,
 		LogWriter:      logWriter,
 		TimeoutSeconds: int(timeout.Seconds()),
+		MCPConfigPath:  mcpConfigPath,
 	}
 
 	logEvent(logFile, "run_started", map[string]any{
@@ -1001,6 +1046,57 @@ func findWorktreeForBranch(porcelain, branch string) string {
 		}
 	}
 	return ""
+}
+
+// writeMCPConfig writes a temporary MCP config JSON file pointing to the
+// github-mcp-server binary with the given token. Returns the path to the
+// config file and a cleanup function. Returns ("", nil, nil) when TokenSource
+// is nil or the token cannot be obtained (non-fatal: agent runs without MCP).
+func writeMCPConfig(ctx context.Context, ts TokenSource) (path string, cleanup func(), err error) {
+	if ts == nil {
+		return "", func() {}, nil
+	}
+	token, err := ts.Token(ctx)
+	if err != nil {
+		charmlog.Warn("could not obtain GitHub token for MCP server; running without MCP", "error", err)
+		return "", func() {}, nil
+	}
+	if token == "" {
+		return "", func() {}, nil
+	}
+
+	type mcpServer struct {
+		Command string            `json:"command"`
+		Args    []string          `json:"args"`
+		Env     map[string]string `json:"env"`
+	}
+	config := map[string]map[string]mcpServer{
+		"mcpServers": {
+			"github": {
+				Command: "github-mcp-server",
+				Args:    []string{"stdio"},
+				Env:     map[string]string{"GITHUB_TOKEN": token},
+			},
+		},
+	}
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", func() {}, fmt.Errorf("marshal MCP config: %w", err)
+	}
+
+	f, err := os.CreateTemp("", "ariadne-mcp-*.json")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create MCP config file: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(f.Name()) //nolint:errcheck
+		return "", func() {}, fmt.Errorf("write MCP config file: %w", err)
+	}
+	f.Close()
+
+	return f.Name(), func() { os.Remove(f.Name()) }, nil //nolint:errcheck
 }
 
 // loadRebaseWorkflow reads .ariadne/REBASE_WORKFLOW.md from the repo root.

--- a/internal/worksource/github.go
+++ b/internal/worksource/github.go
@@ -41,6 +41,12 @@ type GitHubSource struct {
 	repo           string
 	labelFilter    []string
 	allowedAuthors []string // empty = allow all
+	// tokenSource returns a fresh GitHub token. Non-nil when using GitHub App auth.
+	tokenSource interface {
+		Token(ctx context.Context) (string, error)
+	}
+	// staticToken is used when tokenSource is nil (PAT auth).
+	staticToken string
 }
 
 // NewGitHubSource creates a GitHubSource authenticated with the given token.
@@ -70,21 +76,39 @@ func NewGitHubSource(token, repo string, labelFilter []string, allowedAuthors []
 		}
 		itr := ghinstallation.NewFromAppsTransport(atr, inst.GetID())
 		tc = &http.Client{Transport: itr}
-	} else {
-		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-		tc = oauth2.NewClient(context.Background(), ts)
+		return &GitHubSource{
+			client:         gh.NewClient(tc),
+			owner:          owner,
+			repo:           repoName,
+			labelFilter:    labelFilter,
+			allowedAuthors: allowedAuthors,
+			tokenSource:    itr,
+		}, nil
 	}
 
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tc = oauth2.NewClient(context.Background(), ts)
 	return &GitHubSource{
 		client:         gh.NewClient(tc),
 		owner:          owner,
 		repo:           repoName,
 		labelFilter:    labelFilter,
 		allowedAuthors: allowedAuthors,
+		staticToken:    token,
 	}, nil
 }
 
 func (s *GitHubSource) Name() string { return "github" }
+
+// Token returns a valid GitHub API token. When using GitHub App auth the
+// installation transport handles refresh automatically. Falls back to the
+// static PAT when not using App auth.
+func (s *GitHubSource) Token(ctx context.Context) (string, error) {
+	if s.tokenSource != nil {
+		return s.tokenSource.Token(ctx)
+	}
+	return s.staticToken, nil
+}
 
 // Poll fetches open issues that have all required labels but have NOT been claimed yet.
 func (s *GitHubSource) Poll(ctx context.Context) ([]*domain.Task, error) {


### PR DESCRIPTION
Closes #72

## Summary

- **`GitHubSource.Token(ctx)`**: exposes a fresh GitHub installation token (or static PAT fallback), enabling the supervisor to authenticate the MCP server per-run.
- **`TokenSource` interface + `RunRequest.TokenSource`**: minimal interface the supervisor uses; `GitHubSource` satisfies it automatically, Linear source does not (nil = no MCP).
- **`writeMCPConfig` helper**: writes a temp JSON config file pointing to `github-mcp-server stdio` with the resolved token. Called before launching each agent run (all four paths); nil-safe fallback when no token source is configured.
- **`RunContext.MCPConfigPath`**: plumbed through all provider calls; Claude provider appends `--mcp-config <path>` when set.
- **`tokenSource()` helper in main.go**: extracts `TokenSource` from `WorkSource` via interface assertion.
- **`WORKFLOW.md`**: replaces `gh` CLI instructions with GitHub MCP tool equivalents (`get_issue`, `create_pull_request`, `get_pull_request_checks`, etc.).

## Test plan

- [x] `go test ./...` passes
- [x] `go test -race ./...` passes
- [ ] Agent run claims issue and creates PR as AriadneBot (requires live environment)
- [ ] PR comments posted as AriadneBot (requires live environment)
- [ ] Falls back cleanly when `GH_APP_APP_ID`/`GH_APP_PRIVATE_KEY_PATH` are unset — `writeMCPConfig` returns empty path, Claude runs without `--mcp-config`