### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @haha-systems/maintainers


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning `@haha-systems/maintainers` as the default owner for all files.

Closes #67